### PR TITLE
X2-1506 UI - Cannot select "Relative Date Range" option

### DIFF
--- a/src/components/DatePicker/DatePicker.jsx
+++ b/src/components/DatePicker/DatePicker.jsx
@@ -57,7 +57,6 @@ export const DatePicker = ({
 
     const handleRelativeRangeChanged = (rangeName, range) => {
         setCurrentMonth(range.from);
-        setRangeName(rangeName);
         onChange(range, modifiers, null);
     };
 


### PR DESCRIPTION
Approaching with it so just like it's done in V1 - the dropdown value always stays on default option after choosing another one.