### PR TITLE
Classname Cleanup

### DIFF
--- a/src/components/Buttons/Button.css
+++ b/src/components/Buttons/Button.css
@@ -1,0 +1,92 @@
+.ui-button {
+    @apply inline-flex items-center justify-center rounded border font-semibold transition-colors focus:ring disabled:cursor-default disabled:bg-gray-lighter disabled:text-gray-dark;
+}
+
+.ui-button-tiny {
+    /* 20px */
+    @apply px-2 py-0.5 text-xs leading-xs;
+}
+
+.ui-button-small {
+    /* 30px */
+    @apply h-[30px] px-3 py-2 text-sm leading-sm;
+}
+
+.ui-button-medium {
+    /* 40px */
+    @apply h-[40px] px-4.5 py-3 text-base leading-base;
+}
+
+.ui-button-large {
+    /* 50px */
+    @apply h-[50px] px-6 py-4 text-md leading-md;
+}
+
+.ui-button-standard {
+    @apply border-transparent text-white;
+}
+.ui-button-standard-primary {
+    @apply bg-primary hover:bg-primary-darker active:bg-primary;
+}
+.ui-button-standard-secondary {
+    @apply border-transparent bg-secondary text-white hover:bg-secondary-dark active:bg-secondary;
+}
+.ui-button-standard-success {
+    @apply bg-success hover:bg-success-dark active:bg-success;
+}
+.ui-button-standard-warning {
+    @apply bg-warning hover:bg-warning-dark active:bg-warning;
+}
+.ui-button-standard-caution {
+    @apply bg-caution hover:bg-caution-dark active:bg-caution;
+}
+.ui-button-standard-danger {
+    @apply bg-danger hover:bg-danger-dark active:bg-danger;
+}
+
+.ui-button-outline {
+    @apply border bg-white hover:bg-white active:text-white;
+}
+.ui-button-outline-default {
+    @apply border-gray-light hover:border-gray-dark active:border-primary active:bg-primary-lighter active:text-black;
+}
+.ui-button-outline-primary {
+    @apply border-primary text-primary hover:border-primary-dark hover:text-primary-dark active:bg-primary-light;
+}
+.ui-button-outline-secondary {
+    @apply border-gray-light hover:border-gray-dark active:border-primary active:bg-primary-lighter active:text-black;
+}
+.ui-button-outline-success {
+    @apply text-success border-success hover:text-success-dark hover:border-success-dark active:bg-success-light;
+}
+.ui-button-outline-warning {
+    @apply text-warning border-warning hover:text-warning-dark hover:border-warning-dark active:bg-warning-light;
+}
+.ui-button-outline-caution {
+    @apply text-caution border-caution hover:text-caution-dark hover:border-caution-dark active:bg-caution-light;
+}
+.ui-button-outline-danger {
+    @apply text-danger border-danger hover:text-danger-dark hover:border-danger-dark active:bg-danger-light;
+}
+
+.ui-button-link {
+    @apply border-transparent hover:underline;
+}
+.ui-button-link-primary {
+    @apply text-primary;
+}
+.ui-button-link-secondary {
+    @apply text-secondary;
+}
+.ui-button-link-success {
+    @apply text-success;
+}
+.ui-button-link-warning {
+    @apply text-warning;
+}
+.ui-button-link-caution {
+    @apply text-caution;
+}
+.ui-button-link-danger {
+    @apply text-danger
+}

--- a/src/components/Buttons/Button.jsx
+++ b/src/components/Buttons/Button.jsx
@@ -1,51 +1,7 @@
 import clsx from "clsx";
 import PropTypes from "prop-types";
 import React from "react";
-
-const colors = {
-    standard: {
-        common: "border-transparent text-white", // Common classes for each style
-        primary: "bg-primary hover:bg-primary-darker disabled:bg-primary active:bg-primary",
-        secondary:
-            "bg-secondary text-white hover:bg-secondary-dark disabled:bg-secondary border-transparent active:bg-secondary",
-        success: "bg-success hover:bg-success-dark disabled:bg-success active:bg-success",
-        warning: "bg-warning hover:bg-warning-dark disabled:bg-warning active:bg-warning",
-        caution: "bg-caution hover:bg-caution-dark disabled:bg-caution active:bg-caution",
-        danger: "bg-danger hover:bg-danger-dark disabled:bg-danger active:bg-danger",
-    },
-    outline: {
-        common: "bg-white border hover:bg-white active:text-white", // Common classes for each style
-        default:
-            "border-gray-light hover:border-gray-dark active:bg-primary-lighter active:text-black active:border-primary",
-        primary:
-            "text-primary border-primary hover:text-primary-dark hover:border-primary-dark active:bg-primary-light",
-        secondary:
-            "border-gray-light hover:border-gray-dark active:bg-primary-lighter active:text-black active:border-primary",
-        success:
-            "text-success border-success hover:text-success-dark hover:border-success-dark active:bg-success-light",
-        warning:
-            "text-warning border-warning hover:text-warning-dark hover:border-warning-dark active:bg-warning-light",
-        caution:
-            "text-caution border-caution hover:text-caution-dark hover:border-caution-dark active:bg-caution-light",
-        danger: "text-danger border-danger hover:text-danger-dark hover:border-danger-dark active:bg-danger-light",
-    },
-    link: {
-        common: "border-transparent hover:underline",
-        primary: "text-primary",
-        secondary: "text-secondary",
-        success: "text-success",
-        warning: "text-warning",
-        caution: "text-caution",
-        danger: "text-danger",
-    },
-};
-
-const sizes = {
-    tiny: "px-2 py-0.5 text-xs leading-xs", // 20px
-    small: "px-3 py-2 h-[30px] text-sm leading-sm", // 30px
-    medium: "px-4.5 py-3 h-[40px] text-base leading-base", // 40px
-    large: "px-6 py-4 h-[50px] text-md leading-md", // 50px
-};
+import "./Button.css";
 
 export const Button = ({
     as: Tag = "button",
@@ -62,11 +18,8 @@ export const Button = ({
         <Tag
             className={clsx(
                 "ui-button",
-                "inline-flex rounded border transition-colors focus:ring disabled:cursor-default disabled:bg-gray-lighter disabled:text-gray-dark",
-                "items-center justify-center font-semibold",
-                colors[variant].common,
-                colors[variant][color],
-                sizes[size],
+                `ui-button-${size}`,
+                `ui-button-${variant} ui-button-${variant}-${color}`,
                 className,
             )}
             {...rest}
@@ -78,11 +31,15 @@ export const Button = ({
     );
 };
 
+const sizes = ["tiny", "sma;", "small", "medium", "large"];
+const colors = ["primary", "secondary", "success", "danger", "caution", "warning"];
+const variants = ["standard", "outline", "link"];
+
 Button.propTypes = {
     // as: PropTypes.string,
-    color: PropTypes.oneOf(Object.keys(colors.outline)),
-    variant: PropTypes.oneOf(Object.keys(colors)),
-    size: PropTypes.oneOf(Object.keys(sizes)),
+    color: PropTypes.oneOf(colors),
+    variant: PropTypes.oneOf(variants),
+    size: PropTypes.oneOf(sizes),
     className: PropTypes.string,
     children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
     icon(props, ...rest) {


### PR DESCRIPTION
The problem is the traditional Tailwind usage style means there are a lot of classes in your markup.
For development this is not a problem but when inspecting the markup in a console or changing classes
or attributes during debugging it makes a little inconvenient. 

For the UI Kit this makes sense because for basic components the classnames are unlikely to change
