### PR TITLE
Add Figma Design Links to Storybooks

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,7 +4,13 @@ module.exports = {
     addons: [
         "@storybook/addon-postcss",
         "@storybook/addon-links",
-        "@storybook/addon-essentials",
         "storybook-css-modules-preset",
+        "storybook-addon-designs",
+        {
+            name: "@storybook/addon-essentials",
+            options: {
+                backgrounds: false,
+            },
+        },
     ],
 };

--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -8,7 +8,7 @@
     document.title = "Xola UI Kit";
 </script>
 <style type="text/css">
-    /* Make the style consistent with the Xola theme. This can't be styled by variables so raw CSS is neeeded */
+    /* Make the style consistent with the Xola theme. This can't be styled by variables so raw CSS is needed */
     .sidebar-subheading {
         color: #505254 !important; /* text-gray-darker */
         font-size: 12px !important;

--- a/.storybook/xola.js
+++ b/.storybook/xola.js
@@ -32,5 +32,5 @@ export default create({
     inputBorderRadius: 4,
 
     brandTitle: "Xola's UI Components",
-    brandImage: "https://xola.com/images/xola-logo-header.png",
+    brandImage: "https://www.xola.com/wp-content/themes/xola/assets/images/Xola.svg",
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
                 "react-hotkeys-hook": "^3.4.0",
                 "react-json-view": "^1.21.3",
                 "react-select": "^5.1.0",
+                "storybook-addon-designs": "^6.3.1",
                 "tippy.js": "^6.3.1",
                 "typescript": "4.7"
             },
@@ -2025,6 +2026,26 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/@figspec/components": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@figspec/components/-/components-1.0.1.tgz",
+            "integrity": "sha512-UvnEamPEAMh9HExViqpobWmX25g1+soA9kcJu+It3VerMa7CeVyaIbQydNf1Gys5v/rxJVdTDRgQ7OXW2zAAig==",
+            "dependencies": {
+                "lit": "^2.1.3"
+            }
+        },
+        "node_modules/@figspec/react": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@figspec/react/-/react-1.0.3.tgz",
+            "integrity": "sha512-r683qOko+5CbT48Ox280fMx2MNAtaFPgCNJvldOqN3YtmAzlcTT+YSxd3OahA+kjXGGrnzDbUgeTOX1cPLII+g==",
+            "dependencies": {
+                "@figspec/components": "^1.0.1",
+                "@lit-labs/react": "^1.0.2"
+            },
+            "peerDependencies": {
+                "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
         "node_modules/@gar/promisify": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
@@ -3404,6 +3425,16 @@
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
             }
+        },
+        "node_modules/@lit-labs/react": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@lit-labs/react/-/react-1.1.0.tgz",
+            "integrity": "sha512-uvdOtzACm1WzTySpKnqXth62iPL+4yDow7cSZH7m7jHbDr+tZVXn44DJ5IoJuMjEevORRe57lNrOywFW6d4Fyg=="
+        },
+        "node_modules/@lit/reactive-element": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.4.2.tgz",
+            "integrity": "sha512-VMOxsWh/QDwrxPsgkSQnuZ+8mfNy1OTjzzUdLBvvZtpahwPTHTeVZ51RZRqO4xfKVrR+btIPA8D01IL3xeG66w=="
         },
         "node_modules/@mdx-js/mdx": {
             "version": "1.6.22",
@@ -8820,6 +8851,11 @@
             "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.8.tgz",
             "integrity": "sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==",
             "dev": true
+        },
+        "node_modules/@types/trusted-types": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
+            "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
         },
         "node_modules/@types/uglify-js": {
             "version": "3.17.1",
@@ -21109,6 +21145,33 @@
             "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
             "dev": true
         },
+        "node_modules/lit": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/lit/-/lit-2.4.1.tgz",
+            "integrity": "sha512-qohSgLiyN1cFnJG26dIiY03S4F49857A0AHQfnS0zYtnUVnD2MFvx+UT52rtXsIuNFQrnUupX+zyGSATlk1f/A==",
+            "dependencies": {
+                "@lit/reactive-element": "^1.4.0",
+                "lit-element": "^3.2.0",
+                "lit-html": "^2.4.0"
+            }
+        },
+        "node_modules/lit-element": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.2.2.tgz",
+            "integrity": "sha512-6ZgxBR9KNroqKb6+htkyBwD90XGRiqKDHVrW/Eh0EZ+l+iC+u+v+w3/BA5NGi4nizAVHGYvQBHUDuSmLjPp7NQ==",
+            "dependencies": {
+                "@lit/reactive-element": "^1.3.0",
+                "lit-html": "^2.2.0"
+            }
+        },
+        "node_modules/lit-html": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.4.0.tgz",
+            "integrity": "sha512-G6qXu4JNUpY6aaF2VMfaszhO9hlWw0hOTRFDmuMheg/nDYGB+2RztUSOyrzALAbr8Nh0Y7qjhYkReh3rPnplVg==",
+            "dependencies": {
+                "@types/trusted-types": "^2.0.2"
+            }
+        },
         "node_modules/loader-runner": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
@@ -26383,6 +26446,14 @@
             "integrity": "sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==",
             "dev": true
         },
+        "node_modules/storybook-addon-designs": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/storybook-addon-designs/-/storybook-addon-designs-6.3.1.tgz",
+            "integrity": "sha512-QCHZp4KuUikOq52MPiMfU8QifYTfhHar5vWlbcfkFDz1YrgGMy+QAEt5Y3Vdnffl4GKSK1lAsLuvTuzqTBRvnw==",
+            "dependencies": {
+                "@figspec/react": "^1.0.0"
+            }
+        },
         "node_modules/storybook-css-modules-preset": {
             "version": "1.1.1",
             "integrity": "sha512-wyINPOtB/8SvU7J92ePAhciBk4xoHuwrcqDNyGnSwilwHjmtHwbeEgZ1//JALOTwMB10zwz3WPONRkWec9LdGw==",
@@ -29165,6 +29236,7 @@
         },
         "node_modules/xo/node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -29177,6 +29249,7 @@
         },
         "node_modules/xo/node_modules/@nodelib/fs.stat": {
             "version": "2.0.5",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -29185,6 +29258,7 @@
         },
         "node_modules/xo/node_modules/@nodelib/fs.walk": {
             "version": "1.2.8",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -29197,11 +29271,13 @@
         },
         "node_modules/xo/node_modules/@types/json-schema": {
             "version": "7.0.11",
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/xo/node_modules/@typescript-eslint/eslint-plugin": {
             "version": "5.27.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -29234,6 +29310,7 @@
         },
         "node_modules/xo/node_modules/@typescript-eslint/parser": {
             "version": "5.27.1",
+            "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -29260,6 +29337,7 @@
         },
         "node_modules/xo/node_modules/@typescript-eslint/scope-manager": {
             "version": "5.27.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -29276,6 +29354,7 @@
         },
         "node_modules/xo/node_modules/@typescript-eslint/type-utils": {
             "version": "5.27.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -29301,6 +29380,7 @@
         },
         "node_modules/xo/node_modules/@typescript-eslint/types": {
             "version": "5.27.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -29313,6 +29393,7 @@
         },
         "node_modules/xo/node_modules/@typescript-eslint/typescript-estree": {
             "version": "5.27.1",
+            "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -29339,6 +29420,7 @@
         },
         "node_modules/xo/node_modules/@typescript-eslint/typescript-estree/node_modules/globby": {
             "version": "11.1.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -29358,6 +29440,7 @@
         },
         "node_modules/xo/node_modules/@typescript-eslint/typescript-estree/node_modules/slash": {
             "version": "3.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -29366,6 +29449,7 @@
         },
         "node_modules/xo/node_modules/@typescript-eslint/utils": {
             "version": "5.27.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -29389,6 +29473,7 @@
         },
         "node_modules/xo/node_modules/@typescript-eslint/visitor-keys": {
             "version": "5.27.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -29405,6 +29490,7 @@
         },
         "node_modules/xo/node_modules/array-union": {
             "version": "2.1.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -29425,6 +29511,7 @@
         },
         "node_modules/xo/node_modules/braces": {
             "version": "3.0.2",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -29436,6 +29523,7 @@
         },
         "node_modules/xo/node_modules/debug": {
             "version": "4.3.4",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -29452,11 +29540,13 @@
         },
         "node_modules/xo/node_modules/debug/node_modules/ms": {
             "version": "2.1.2",
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/xo/node_modules/dir-glob": {
             "version": "3.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -29468,6 +29558,7 @@
         },
         "node_modules/xo/node_modules/eslint-config-xo-typescript": {
             "version": "0.51.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -29484,6 +29575,7 @@
         },
         "node_modules/xo/node_modules/eslint-scope": {
             "version": "5.1.1",
+            "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -29496,6 +29588,7 @@
         },
         "node_modules/xo/node_modules/eslint-scope/node_modules/estraverse": {
             "version": "4.3.0",
+            "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
             "engines": {
@@ -29504,6 +29597,7 @@
         },
         "node_modules/xo/node_modules/eslint-utils": {
             "version": "3.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -29521,6 +29615,7 @@
         },
         "node_modules/xo/node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
             "version": "2.1.0",
+            "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "engines": {
@@ -29529,6 +29624,7 @@
         },
         "node_modules/xo/node_modules/eslint-visitor-keys": {
             "version": "3.3.0",
+            "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "engines": {
@@ -29537,6 +29633,7 @@
         },
         "node_modules/xo/node_modules/esrecurse": {
             "version": "4.3.0",
+            "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -29548,6 +29645,7 @@
         },
         "node_modules/xo/node_modules/estraverse": {
             "version": "5.3.0",
+            "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
             "engines": {
@@ -29556,6 +29654,7 @@
         },
         "node_modules/xo/node_modules/fast-glob": {
             "version": "3.2.11",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -29571,6 +29670,7 @@
         },
         "node_modules/xo/node_modules/fastq": {
             "version": "1.13.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -29579,6 +29679,7 @@
         },
         "node_modules/xo/node_modules/fill-range": {
             "version": "7.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -29623,11 +29724,13 @@
         },
         "node_modules/xo/node_modules/functional-red-black-tree": {
             "version": "1.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/xo/node_modules/glob-parent": {
             "version": "5.1.2",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -29658,6 +29761,7 @@
         },
         "node_modules/xo/node_modules/ignore": {
             "version": "5.2.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -29666,6 +29770,7 @@
         },
         "node_modules/xo/node_modules/is-extglob": {
             "version": "2.1.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -29674,6 +29779,7 @@
         },
         "node_modules/xo/node_modules/is-glob": {
             "version": "4.0.3",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -29685,6 +29791,7 @@
         },
         "node_modules/xo/node_modules/is-number": {
             "version": "7.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -29708,6 +29815,7 @@
         },
         "node_modules/xo/node_modules/lru-cache": {
             "version": "6.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -29743,6 +29851,7 @@
         },
         "node_modules/xo/node_modules/merge2": {
             "version": "1.4.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -29751,6 +29860,7 @@
         },
         "node_modules/xo/node_modules/micromatch": {
             "version": "4.0.5",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -29802,6 +29912,7 @@
         },
         "node_modules/xo/node_modules/path-type": {
             "version": "4.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -29810,6 +29921,7 @@
         },
         "node_modules/xo/node_modules/picomatch": {
             "version": "2.3.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -29894,6 +30006,7 @@
         },
         "node_modules/xo/node_modules/queue-microtask": {
             "version": "1.2.3",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -29913,6 +30026,7 @@
         },
         "node_modules/xo/node_modules/regexpp": {
             "version": "3.2.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -29924,6 +30038,7 @@
         },
         "node_modules/xo/node_modules/reusify": {
             "version": "1.0.4",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -29933,6 +30048,7 @@
         },
         "node_modules/xo/node_modules/run-parallel": {
             "version": "1.2.0",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -29955,6 +30071,7 @@
         },
         "node_modules/xo/node_modules/semver": {
             "version": "7.3.7",
+            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -29981,6 +30098,7 @@
         },
         "node_modules/xo/node_modules/to-regex-range": {
             "version": "5.0.1",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -29992,11 +30110,13 @@
         },
         "node_modules/xo/node_modules/tslib": {
             "version": "1.14.1",
+            "dev": true,
             "inBundle": true,
             "license": "0BSD"
         },
         "node_modules/xo/node_modules/tsutils": {
             "version": "3.21.0",
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -30011,6 +30131,7 @@
         },
         "node_modules/xo/node_modules/yallist": {
             "version": "4.0.0",
+            "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
@@ -31435,6 +31556,23 @@
                 }
             }
         },
+        "@figspec/components": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@figspec/components/-/components-1.0.1.tgz",
+            "integrity": "sha512-UvnEamPEAMh9HExViqpobWmX25g1+soA9kcJu+It3VerMa7CeVyaIbQydNf1Gys5v/rxJVdTDRgQ7OXW2zAAig==",
+            "requires": {
+                "lit": "^2.1.3"
+            }
+        },
+        "@figspec/react": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@figspec/react/-/react-1.0.3.tgz",
+            "integrity": "sha512-r683qOko+5CbT48Ox280fMx2MNAtaFPgCNJvldOqN3YtmAzlcTT+YSxd3OahA+kjXGGrnzDbUgeTOX1cPLII+g==",
+            "requires": {
+                "@figspec/components": "^1.0.1",
+                "@lit-labs/react": "^1.0.2"
+            }
+        },
         "@gar/promisify": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
@@ -32472,6 +32610,16 @@
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
             }
+        },
+        "@lit-labs/react": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@lit-labs/react/-/react-1.1.0.tgz",
+            "integrity": "sha512-uvdOtzACm1WzTySpKnqXth62iPL+4yDow7cSZH7m7jHbDr+tZVXn44DJ5IoJuMjEevORRe57lNrOywFW6d4Fyg=="
+        },
+        "@lit/reactive-element": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.4.2.tgz",
+            "integrity": "sha512-VMOxsWh/QDwrxPsgkSQnuZ+8mfNy1OTjzzUdLBvvZtpahwPTHTeVZ51RZRqO4xfKVrR+btIPA8D01IL3xeG66w=="
         },
         "@mdx-js/mdx": {
             "version": "1.6.22",
@@ -36308,6 +36456,11 @@
             "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.8.tgz",
             "integrity": "sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==",
             "dev": true
+        },
+        "@types/trusted-types": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
+            "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
         },
         "@types/uglify-js": {
             "version": "3.17.1",
@@ -45500,6 +45653,33 @@
             "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
             "dev": true
         },
+        "lit": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/lit/-/lit-2.4.1.tgz",
+            "integrity": "sha512-qohSgLiyN1cFnJG26dIiY03S4F49857A0AHQfnS0zYtnUVnD2MFvx+UT52rtXsIuNFQrnUupX+zyGSATlk1f/A==",
+            "requires": {
+                "@lit/reactive-element": "^1.4.0",
+                "lit-element": "^3.2.0",
+                "lit-html": "^2.4.0"
+            }
+        },
+        "lit-element": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.2.2.tgz",
+            "integrity": "sha512-6ZgxBR9KNroqKb6+htkyBwD90XGRiqKDHVrW/Eh0EZ+l+iC+u+v+w3/BA5NGi4nizAVHGYvQBHUDuSmLjPp7NQ==",
+            "requires": {
+                "@lit/reactive-element": "^1.3.0",
+                "lit-html": "^2.2.0"
+            }
+        },
+        "lit-html": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.4.0.tgz",
+            "integrity": "sha512-G6qXu4JNUpY6aaF2VMfaszhO9hlWw0hOTRFDmuMheg/nDYGB+2RztUSOyrzALAbr8Nh0Y7qjhYkReh3rPnplVg==",
+            "requires": {
+                "@types/trusted-types": "^2.0.2"
+            }
+        },
         "loader-runner": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
@@ -49568,6 +49748,14 @@
             "integrity": "sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==",
             "dev": true
         },
+        "storybook-addon-designs": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/storybook-addon-designs/-/storybook-addon-designs-6.3.1.tgz",
+            "integrity": "sha512-QCHZp4KuUikOq52MPiMfU8QifYTfhHar5vWlbcfkFDz1YrgGMy+QAEt5Y3Vdnffl4GKSK1lAsLuvTuzqTBRvnw==",
+            "requires": {
+                "@figspec/react": "^1.0.0"
+            }
+        },
         "storybook-css-modules-preset": {
             "version": "1.1.1",
             "integrity": "sha512-wyINPOtB/8SvU7J92ePAhciBk4xoHuwrcqDNyGnSwilwHjmtHwbeEgZ1//JALOTwMB10zwz3WPONRkWec9LdGw==",
@@ -51696,6 +51884,7 @@
                 "@nodelib/fs.scandir": {
                     "version": "2.1.5",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "@nodelib/fs.stat": "2.0.5",
                         "run-parallel": "^1.1.9"
@@ -51703,11 +51892,13 @@
                 },
                 "@nodelib/fs.stat": {
                     "version": "2.0.5",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true
                 },
                 "@nodelib/fs.walk": {
                     "version": "1.2.8",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "@nodelib/fs.scandir": "2.1.5",
                         "fastq": "^1.6.0"
@@ -51715,11 +51906,13 @@
                 },
                 "@types/json-schema": {
                     "version": "7.0.11",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true
                 },
                 "@typescript-eslint/eslint-plugin": {
                     "version": "5.27.1",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "@typescript-eslint/scope-manager": "5.27.1",
                         "@typescript-eslint/type-utils": "5.27.1",
@@ -51735,6 +51928,7 @@
                 "@typescript-eslint/parser": {
                     "version": "5.27.1",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "@typescript-eslint/scope-manager": "5.27.1",
                         "@typescript-eslint/types": "5.27.1",
@@ -51745,6 +51939,7 @@
                 "@typescript-eslint/scope-manager": {
                     "version": "5.27.1",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "@typescript-eslint/types": "5.27.1",
                         "@typescript-eslint/visitor-keys": "5.27.1"
@@ -51753,6 +51948,7 @@
                 "@typescript-eslint/type-utils": {
                     "version": "5.27.1",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "@typescript-eslint/utils": "5.27.1",
                         "debug": "^4.3.4",
@@ -51761,11 +51957,13 @@
                 },
                 "@typescript-eslint/types": {
                     "version": "5.27.1",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true
                 },
                 "@typescript-eslint/typescript-estree": {
                     "version": "5.27.1",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "@typescript-eslint/types": "5.27.1",
                         "@typescript-eslint/visitor-keys": "5.27.1",
@@ -51779,6 +51977,7 @@
                         "globby": {
                             "version": "11.1.0",
                             "bundled": true,
+                            "dev": true,
                             "requires": {
                                 "array-union": "^2.1.0",
                                 "dir-glob": "^3.0.1",
@@ -51790,13 +51989,15 @@
                         },
                         "slash": {
                             "version": "3.0.0",
-                            "bundled": true
+                            "bundled": true,
+                            "dev": true
                         }
                     }
                 },
                 "@typescript-eslint/utils": {
                     "version": "5.27.1",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "@types/json-schema": "^7.0.9",
                         "@typescript-eslint/scope-manager": "5.27.1",
@@ -51809,6 +52010,7 @@
                 "@typescript-eslint/visitor-keys": {
                     "version": "5.27.1",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "@typescript-eslint/types": "5.27.1",
                         "eslint-visitor-keys": "^3.3.0"
@@ -51816,7 +52018,8 @@
                 },
                 "array-union": {
                     "version": "2.1.0",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true
                 },
                 "arrify": {
                     "version": "3.0.0",
@@ -51827,6 +52030,7 @@
                 "braces": {
                     "version": "3.0.2",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "fill-range": "^7.0.1"
                     }
@@ -51834,30 +52038,35 @@
                 "debug": {
                     "version": "4.3.4",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "ms": "2.1.2"
                     },
                     "dependencies": {
                         "ms": {
                             "version": "2.1.2",
-                            "bundled": true
+                            "bundled": true,
+                            "dev": true
                         }
                     }
                 },
                 "dir-glob": {
                     "version": "3.0.1",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "path-type": "^4.0.0"
                     }
                 },
                 "eslint-config-xo-typescript": {
                     "version": "0.51.1",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true
                 },
                 "eslint-scope": {
                     "version": "5.1.1",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "esrecurse": "^4.3.0",
                         "estraverse": "^4.1.1"
@@ -51865,41 +52074,48 @@
                     "dependencies": {
                         "estraverse": {
                             "version": "4.3.0",
-                            "bundled": true
+                            "bundled": true,
+                            "dev": true
                         }
                     }
                 },
                 "eslint-utils": {
                     "version": "3.0.0",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "eslint-visitor-keys": "^2.0.0"
                     },
                     "dependencies": {
                         "eslint-visitor-keys": {
                             "version": "2.1.0",
-                            "bundled": true
+                            "bundled": true,
+                            "dev": true
                         }
                     }
                 },
                 "eslint-visitor-keys": {
                     "version": "3.3.0",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true
                 },
                 "esrecurse": {
                     "version": "4.3.0",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "estraverse": "^5.2.0"
                     }
                 },
                 "estraverse": {
                     "version": "5.3.0",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true
                 },
                 "fast-glob": {
                     "version": "3.2.11",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "@nodelib/fs.stat": "^2.0.2",
                         "@nodelib/fs.walk": "^1.2.3",
@@ -51911,6 +52127,7 @@
                 "fastq": {
                     "version": "1.13.0",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "reusify": "^1.0.4"
                     }
@@ -51918,6 +52135,7 @@
                 "fill-range": {
                     "version": "7.0.1",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "to-regex-range": "^5.0.1"
                     }
@@ -51945,11 +52163,13 @@
                 },
                 "functional-red-black-tree": {
                     "version": "1.0.1",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true
                 },
                 "glob-parent": {
                     "version": "5.1.2",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "is-glob": "^4.0.1"
                     }
@@ -51969,22 +52189,26 @@
                 },
                 "ignore": {
                     "version": "5.2.0",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true
                 },
                 "is-extglob": {
                     "version": "2.1.1",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true
                 },
                 "is-glob": {
                     "version": "4.0.3",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "is-extglob": "^2.1.1"
                     }
                 },
                 "is-number": {
                     "version": "7.0.0",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true
                 },
                 "locate-path": {
                     "version": "7.1.1",
@@ -51998,6 +52222,7 @@
                 "lru-cache": {
                     "version": "6.0.0",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "yallist": "^4.0.0"
                     }
@@ -52021,11 +52246,13 @@
                 },
                 "merge2": {
                     "version": "1.4.1",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true
                 },
                 "micromatch": {
                     "version": "4.0.5",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "braces": "^3.0.2",
                         "picomatch": "^2.3.1"
@@ -52057,11 +52284,13 @@
                 },
                 "path-type": {
                     "version": "4.0.0",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true
                 },
                 "picomatch": {
                     "version": "2.3.1",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true
                 },
                 "pkg-dir": {
                     "version": "4.2.0",
@@ -52119,19 +52348,23 @@
                 },
                 "queue-microtask": {
                     "version": "1.2.3",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true
                 },
                 "regexpp": {
                     "version": "3.2.0",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true
                 },
                 "reusify": {
                     "version": "1.0.4",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true
                 },
                 "run-parallel": {
                     "version": "1.2.0",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "queue-microtask": "^1.2.2"
                     }
@@ -52139,6 +52372,7 @@
                 "semver": {
                     "version": "7.3.7",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
                     }
@@ -52152,24 +52386,28 @@
                 "to-regex-range": {
                     "version": "5.0.1",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "is-number": "^7.0.0"
                     }
                 },
                 "tslib": {
                     "version": "1.14.1",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true
                 },
                 "tsutils": {
                     "version": "3.21.0",
                     "bundled": true,
+                    "dev": true,
                     "requires": {
                         "tslib": "^1.8.1"
                     }
                 },
                 "yallist": {
                     "version": "4.0.0",
-                    "bundled": true
+                    "bundled": true,
+                    "dev": true
                 },
                 "yocto-queue": {
                     "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "react-hotkeys-hook": "^3.4.0",
         "react-json-view": "^1.21.3",
         "react-select": "^5.1.0",
+        "storybook-addon-designs": "^6.3.1",
         "tippy.js": "^6.3.1",
         "typescript": "4.7"
     },

--- a/src/stories/Configuration/Colors.stories.js
+++ b/src/stories/Configuration/Colors.stories.js
@@ -4,6 +4,12 @@ import twConfig from "../../../tailwind.config";
 
 const ColorsStories = {
     title: "Configuration/Colors",
+    parameters: {
+        design: {
+            type: "figma",
+            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=2855%3A99352&viewport=3792%2C737%2C0.13",
+        },
+    },
 };
 
 const { colors } = twConfig.theme;

--- a/src/stories/Configuration/Colors.stories.js
+++ b/src/stories/Configuration/Colors.stories.js
@@ -6,6 +6,7 @@ const ColorsStories = {
     title: "Configuration/Colors",
     parameters: {
         design: {
+            name: "Figma",
             type: "figma",
             url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=2855%3A99352&viewport=3792%2C737%2C0.13",
         },

--- a/src/stories/Configuration/Config.stories.js
+++ b/src/stories/Configuration/Config.stories.js
@@ -15,7 +15,7 @@ export const UIKitRawConfig = () => {
             </div>
             <ReactJson
                 src={theme}
-                name="./tailwind.config.js"
+                name={false}
                 quotesOnKeys={false}
                 collapsed={2}
                 enableClipboard={false}

--- a/src/stories/Configuration/Fonts.stories.js
+++ b/src/stories/Configuration/Fonts.stories.js
@@ -3,6 +3,12 @@ import twConfig from "../../../tailwind.config";
 
 const FontsStories = {
     title: "Configuration/Fonts",
+    parameters: {
+        design: {
+            type: "figma",
+            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=2855%3A99412&viewport=7782%2C1364%2C0.44",
+        },
+    },
 };
 
 export const Fonts = () => {

--- a/src/stories/Configuration/Fonts.stories.js
+++ b/src/stories/Configuration/Fonts.stories.js
@@ -5,6 +5,7 @@ const FontsStories = {
     title: "Configuration/Fonts",
     parameters: {
         design: {
+            name: "Figma",
             type: "figma",
             url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=2855%3A99412&viewport=7782%2C1364%2C0.44",
         },

--- a/src/stories/Configuration/Fonts.stories.js
+++ b/src/stories/Configuration/Fonts.stories.js
@@ -7,7 +7,7 @@ const FontsStories = {
         design: {
             name: "Figma",
             type: "figma",
-            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=2855%3A99412&viewport=7782%2C1364%2C0.44",
+            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=2855%3A99422",
         },
     },
 };

--- a/src/stories/Configuration/Links.stories.js
+++ b/src/stories/Configuration/Links.stories.js
@@ -2,6 +2,12 @@ import React from "react";
 
 const LinksStories = {
     title: "Configuration/Links",
+    parameters: {
+        design: {
+            type: "figma",
+            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=2855%3A99459",
+        },
+    },
 };
 
 export const Links = () => {

--- a/src/stories/Configuration/Paragraphs.stories.js
+++ b/src/stories/Configuration/Paragraphs.stories.js
@@ -2,6 +2,12 @@ import React from "react";
 
 const ParagraphsStories = {
     title: "Configuration/Paragraph",
+    parameters: {
+        design: {
+            type: "figma",
+            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=2855%3A99446",
+        },
+    },
 };
 
 export const Paragraph = () => {

--- a/src/stories/Configuration/Spacing.stories.js
+++ b/src/stories/Configuration/Spacing.stories.js
@@ -3,6 +3,13 @@ import twConfig from "../../../tailwind.config";
 
 const SpacingStories = {
     title: "Configuration/Spacing",
+    parameters: {
+        design: {
+            name: "Figma",
+            type: "figma",
+            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=4308%3A146977",
+        },
+    },
 };
 
 const { spacing } = twConfig.theme;

--- a/src/stories/Configuration/Text.stories.js
+++ b/src/stories/Configuration/Text.stories.js
@@ -2,6 +2,12 @@ import React from "react";
 
 const TextStories = {
     title: "Configuration/Text",
+    parameters: {
+        design: {
+            type: "figma",
+            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=2855%3A99414",
+        },
+    },
 };
 
 export const Text = () => {

--- a/src/stories/DataDisplay/Alert.stories.js
+++ b/src/stories/DataDisplay/Alert.stories.js
@@ -11,6 +11,7 @@ const AlertStories = {
             },
         },
         design: {
+            name: "Figma",
             type: "figma",
             url: "https://www.figma.com/file/EFmxLREOeGUse5zksD3iT4/%E2%9A%99%EF%B8%8F-02---DS-Application-UI?node-id=198%3A110085&viewport=-5176%2C179%2C0.57",
         },

--- a/src/stories/DataDisplay/Alert.stories.js
+++ b/src/stories/DataDisplay/Alert.stories.js
@@ -10,6 +10,10 @@ const AlertStories = {
                 component: "Alerts are short one line components whereas banners are multi-line versions of banners",
             },
         },
+        design: {
+            type: "figma",
+            url: "https://www.figma.com/file/EFmxLREOeGUse5zksD3iT4/%E2%9A%99%EF%B8%8F-02---DS-Application-UI?node-id=198%3A110085&viewport=-5176%2C179%2C0.57",
+        },
     },
     args: {
         text: "Space, the final frontier. These are the voyages of the starship Enterprise. Its five year mission: to explore strange new worlds, to seek out new life and new civilizations, to boldly go where no man has gone before!",

--- a/src/stories/DataDisplay/Badge.stories.js
+++ b/src/stories/DataDisplay/Badge.stories.js
@@ -9,6 +9,12 @@ const BadgeStories = {
         color: "primary",
         size: "small",
     },
+    parameters: {
+        design: {
+            type: "figma",
+            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=384%3A60",
+        },
+    },
     argTypes: {
         text: {
             type: { required: true },

--- a/src/stories/DataDisplay/Badge.stories.js
+++ b/src/stories/DataDisplay/Badge.stories.js
@@ -11,6 +11,7 @@ const BadgeStories = {
     },
     parameters: {
         design: {
+            name: "Figma",
             type: "figma",
             url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=384%3A60",
         },

--- a/src/stories/DataDisplay/Counter.stories.js
+++ b/src/stories/DataDisplay/Counter.stories.js
@@ -11,6 +11,11 @@ const CounterStories = {
                 component: "Component to show a simple count. In one color only for now",
             },
         },
+        design: {
+            name: "Figma",
+            type: "figma",
+            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=1962%3A67978",
+        },
     },
 };
 

--- a/src/stories/DataDisplay/DatePicker.stories.js
+++ b/src/stories/DataDisplay/DatePicker.stories.js
@@ -13,6 +13,11 @@ const DatePickerStories = {
                     "Rendering a date picker with various functionality based on [React Day Picker](https://react-day-picker.js.org) library",
             },
         },
+        design: {
+            name: "Figma",
+            type: "figma",
+            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=2746%3A97005",
+        },
     },
 };
 

--- a/src/stories/DataDisplay/DateRangePicker.stories.js
+++ b/src/stories/DataDisplay/DateRangePicker.stories.js
@@ -12,6 +12,11 @@ const DateRangePickerStories = {
                     "Rendering a date *range* picker with various functionality based on [React Day Picker](https://react-day-picker.js.org) library",
             },
         },
+        design: {
+            name: "Figma",
+            type: "figma",
+            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=3063%3A140153",
+        },
     },
     args: {
         shouldShowRelativeRanges: "boolean",

--- a/src/stories/DataDisplay/Table.stories.js
+++ b/src/stories/DataDisplay/Table.stories.js
@@ -10,6 +10,10 @@ const TableStories = {
                 component: "Your standard Table with a few bells and whistles",
             },
         },
+        design: {
+            type: "figma",
+            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=7839%3A479698&viewport=5709%2C-1661%2C0.26",
+        },
     },
     argTypes: {
         "Table.Header": {

--- a/src/stories/DataDisplay/Table.stories.js
+++ b/src/stories/DataDisplay/Table.stories.js
@@ -11,6 +11,7 @@ const TableStories = {
             },
         },
         design: {
+            name: "Figma",
             type: "figma",
             url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=7839%3A479698&viewport=5709%2C-1661%2C0.26",
         },

--- a/src/stories/DataDisplay/Tag.stories.js
+++ b/src/stories/DataDisplay/Tag.stories.js
@@ -9,6 +9,13 @@ const TagStories = {
         size: "medium",
         text: "Listing: Kayaking in the Ganges",
     },
+    parameters: {
+        design: {
+            name: "Figma",
+            type: "figma",
+            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=384%3A60",
+        },
+    },
     argTypes: {
         text: {
             type: { required: true },

--- a/src/stories/Forms/Button.stories.js
+++ b/src/stories/Forms/Button.stories.js
@@ -6,6 +6,7 @@ const ButtonStories = {
     component: Button,
     parameters: {
         design: {
+            name: "Figma",
             type: "figma",
             url: "https://www.figma.com/file/EFmxLREOeGUse5zksD3iT4/%E2%9A%99%EF%B8%8F-02---DS-Application-UI?node-id=196%3A103411&viewport=-3086%2C515%2C0.36",
         },

--- a/src/stories/Forms/Button.stories.js
+++ b/src/stories/Forms/Button.stories.js
@@ -4,6 +4,12 @@ import { Button, EllipsisIcon, KeyIcon, PlusIcon, UserIcon, WaitlistIcon, Warnin
 const ButtonStories = {
     title: "Forms & Fields/Buttons/Button",
     component: Button,
+    parameters: {
+        design: {
+            type: "figma",
+            url: "https://www.figma.com/file/EFmxLREOeGUse5zksD3iT4/%E2%9A%99%EF%B8%8F-02---DS-Application-UI?node-id=196%3A103411&viewport=-3086%2C515%2C0.36",
+        },
+    },
     args: {
         as: "button",
         size: "medium",

--- a/src/stories/Forms/ButtonGroup.stories.js
+++ b/src/stories/Forms/ButtonGroup.stories.js
@@ -7,6 +7,13 @@ const ButtonGroupStories = {
     args: {
         size: "medium",
     },
+    parameters: {
+        design: {
+            name: "Figma",
+            type: "figma",
+            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=1312%3A44024",
+        },
+    },
     argTypes: {
         size: {
             options: ["small", "medium", "large"],

--- a/src/stories/Forms/ButtonGroup.stories.js
+++ b/src/stories/Forms/ButtonGroup.stories.js
@@ -11,7 +11,7 @@ const ButtonGroupStories = {
         design: {
             name: "Figma",
             type: "figma",
-            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=1312%3A44024",
+            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=7456%3A467977",
         },
     },
     argTypes: {

--- a/src/stories/Forms/Checkbox.stories.js
+++ b/src/stories/Forms/Checkbox.stories.js
@@ -11,6 +11,7 @@ const CheckboxStories = {
             },
         },
         design: {
+            name: "Figma",
             type: "figma",
             url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=7683%3A483048&viewport=7074%2C-1137%2C0.4",
         },

--- a/src/stories/Forms/Checkbox.stories.js
+++ b/src/stories/Forms/Checkbox.stories.js
@@ -10,6 +10,10 @@ const CheckboxStories = {
                 component: "Native browser checkbox component with some styling",
             },
         },
+        design: {
+            type: "figma",
+            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=7683%3A483048&viewport=7074%2C-1137%2C0.4",
+        },
     },
 };
 

--- a/src/stories/Forms/InlineValuePopover.stories.js
+++ b/src/stories/Forms/InlineValuePopover.stories.js
@@ -5,6 +5,13 @@ import { Button, FormGroup, InlineValuePopover, Input, Select } from "../..";
 const InlineValuePopoverStories = {
     title: "Forms & Fields/Inline Value Popover",
     component: InlineValuePopover,
+    parameters: {
+        design: {
+            name: "Figma",
+            type: "figma",
+            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=1481%3A53710",
+        },
+    },
 };
 
 export const Default = () => {

--- a/src/stories/Forms/Input.stories.js
+++ b/src/stories/Forms/Input.stories.js
@@ -6,6 +6,7 @@ const InputStories = {
     title: "Forms & Fields/Input",
     parameters: {
         design: {
+            name: "Figma",
             type: "figma",
             url: "https://www.figma.com/file/EFmxLREOeGUse5zksD3iT4/%E2%9A%99%EF%B8%8F-02---DS-Application-UI?node-id=196%3A113261&viewport=-3655%2C339%2C0.3",
         },

--- a/src/stories/Forms/Input.stories.js
+++ b/src/stories/Forms/Input.stories.js
@@ -4,6 +4,12 @@ import { FormGroup, Input, Label } from "../..";
 const InputStories = {
     primary: true,
     title: "Forms & Fields/Input",
+    parameters: {
+        design: {
+            type: "figma",
+            url: "https://www.figma.com/file/EFmxLREOeGUse5zksD3iT4/%E2%9A%99%EF%B8%8F-02---DS-Application-UI?node-id=196%3A113261&viewport=-3655%2C339%2C0.3",
+        },
+    },
 };
 
 export const Default = () => {

--- a/src/stories/Forms/Switch.stories.js
+++ b/src/stories/Forms/Switch.stories.js
@@ -12,6 +12,7 @@ const SwitchStories = {
             },
         },
         design: {
+            name: "Figma",
             type: "figma",
             url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=7683%3A483033&viewport=7074%2C-1137%2C0.4",
         },

--- a/src/stories/Forms/Switch.stories.js
+++ b/src/stories/Forms/Switch.stories.js
@@ -11,6 +11,10 @@ const SwitchStories = {
                 component: "This is a toggle for situations where you require a better looking boolean form component",
             },
         },
+        design: {
+            type: "figma",
+            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=7683%3A483033&viewport=7074%2C-1137%2C0.4",
+        },
     },
     args: {
         size: "medium",

--- a/src/stories/Forms/Textarea.stories.js
+++ b/src/stories/Forms/Textarea.stories.js
@@ -4,6 +4,13 @@ import { FormGroup, Label, Textarea } from "../..";
 const TextareaStories = {
     primary: true,
     title: "Forms & Fields/Textarea",
+    parameters: {
+        design: {
+            name: "Figma",
+            type: "figma",
+            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=7683%3A479202&viewport=8855%2C-1452%2C0.44",
+        },
+    },
 };
 
 export const Default = () => {

--- a/src/stories/Forms/ToggleButton.stories.js
+++ b/src/stories/Forms/ToggleButton.stories.js
@@ -9,6 +9,13 @@ const ToggleButtonStories = {
         size: "medium",
         isActive: false,
     },
+    parameters: {
+        design: {
+            name: "Figma",
+            type: "figma",
+            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=7505%3A475117",
+        },
+    },
     argTypes: {
         size: {
             options: ["small", "medium", "large"],

--- a/src/stories/Introduction.stories.mdx
+++ b/src/stories/Introduction.stories.mdx
@@ -4,9 +4,9 @@ import { Meta } from "@storybook/addon-docs";
 
 ## Welcome to the Xola UI Kit
 
-This UI Kit is a suite of React components & helper libraries that conform to Xola's design style and brand guidelines which are set by Xola's design team. Components like alerts, avatars, modals, tooltips etc.
+This UI Kit is a suite of React + Tailwind components & helper libraries that conform to Xola's design system and brand guidelines which are set by Xola's design team. Components like alerts, avatars, modals, tooltips etc.
 
-The UI Kit ensures consistent & best practices. It has a friendly development experience by reducing the time you need to spend working on configuring the UX of a component. Everything you see here was built from scratch for the new Xola V2 design.
+The UI Kit ensures consistent & best practices. It has a friendly development experience by reducing the time you need to spend working on configuring the UX of a component. Everything you see here was built from scratch for the new Xola brand.
 
 Click on each component on the left to view it's design. Click on _"Docs"_ in the top toolbar to look at it's configuration parameters which can be tried out live! Click _"Show Code"_ in those boxes to see how to use that component.
 
@@ -25,8 +25,9 @@ See `package.json` for other packages used
 
 ### Links
 
--   https://ui.xola.io via Github at [xola/ui-kit](https://github.com/xola/ui-kit)
--   [@xola/ui-kit](https://www.npmjs.com/package/@xola/ui-kit) on NPM
+-   The Storybook at https://ui.xola.io
+-   The source code on Github [github.com/xola/ui-kit](https://github.com/xola/ui-kit)
+-   The NPM package at [@xola/ui-kit](https://www.npmjs.com/package/@xola/ui-kit)
 
 ### The Magicians
 

--- a/src/stories/Media/Avatar.stories.js
+++ b/src/stories/Media/Avatar.stories.js
@@ -20,6 +20,11 @@ const AvatarStories = {
                     "The avatar component is used to represent a user or seller. If the seller has a profile image that should be used instead",
             },
         },
+        design: {
+            name: "Figma",
+            type: "figma",
+            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=1848%3A51732",
+        },
     },
     args: {
         size: "large",

--- a/src/stories/Media/Icons.stories.js
+++ b/src/stories/Media/Icons.stories.js
@@ -25,6 +25,7 @@ const IconsStories = {
     },
     parameters: {
         design: {
+            name: "Figma",
             type: "figma",
             url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=384%3A0&viewport=4979%2C1071%2C0.31",
         },

--- a/src/stories/Media/Icons.stories.js
+++ b/src/stories/Media/Icons.stories.js
@@ -23,6 +23,12 @@ const IconsStories = {
     args: {
         color: "text-black",
     },
+    parameters: {
+        design: {
+            type: "figma",
+            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=384%3A0&viewport=4979%2C1071%2C0.31",
+        },
+    },
     argTypes: {
         color: {
             description: "Colors",

--- a/src/stories/Media/ImageUpload.stories.js
+++ b/src/stories/Media/ImageUpload.stories.js
@@ -10,6 +10,11 @@ const ImageUploadStories = {
                 component: "Use to upload images",
             },
         },
+        design: {
+            name: "Figma",
+            type: "figma",
+            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=6460%3A394875",
+        },
     },
     args: {
         size: "medium",

--- a/src/stories/Media/Images.stories.js
+++ b/src/stories/Media/Images.stories.js
@@ -22,6 +22,20 @@ const ImagesStories = {
     args: {
         color: "text-black",
     },
+    parameters: {
+        design: [
+            {
+                name: "Original Logos",
+                type: "figma",
+                url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=2391%3A70526",
+            },
+            {
+                name: "New Logos",
+                type: "figma",
+                url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=7869%3A616543",
+            },
+        ],
+    },
     argTypes: {
         color: {
             description: "Colors",

--- a/src/stories/Navigation/Sidebar.stories.js
+++ b/src/stories/Navigation/Sidebar.stories.js
@@ -4,6 +4,12 @@ import { AnnounceIcon, CheckIcon, HelpCenterIcon, LogoutIcon, PolicyIcon, Sideba
 const SidebarStories = {
     title: "Navigation/Sidebar",
     component: Sidebar,
+    parameters: {
+        design: {
+            type: "figma",
+            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=2725%3A91116&viewport=2302%2C256%2C0.11",
+        },
+    },
 };
 
 const SidebarFooter = () => {

--- a/src/stories/Navigation/Sidebar.stories.js
+++ b/src/stories/Navigation/Sidebar.stories.js
@@ -6,6 +6,7 @@ const SidebarStories = {
     component: Sidebar,
     parameters: {
         design: {
+            name: "Figma",
             type: "figma",
             url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=2725%3A91116&viewport=2302%2C256%2C0.11",
         },

--- a/src/stories/Navigation/Tabs.stories.js
+++ b/src/stories/Navigation/Tabs.stories.js
@@ -10,6 +10,11 @@ const TabsStories = {
                 component: "Tabbed interface to show different sections on select of a tab",
             },
         },
+        design: {
+            name: "Figma",
+            type: "figma",
+            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=3355%3A127055",
+        },
     },
     args: {
         variant: "default",

--- a/src/stories/Other/Breakdown.stories.js
+++ b/src/stories/Other/Breakdown.stories.js
@@ -4,6 +4,12 @@ import { Breakdown, Button, CardIcon } from "../..";
 const BreakdownStories = {
     title: "Other/Breakdown",
     component: Breakdown,
+    parameters: {
+        design: {
+            type: "figma",
+            url: "https://www.figma.com/file/EFmxLREOeGUse5zksD3iT4/%E2%9A%99%EF%B8%8F-02---DS-Application-UI?node-id=236%3A144618&viewport=-3895%2C-275%2C0.33",
+        },
+    },
 };
 
 export const Default = () => {

--- a/src/stories/Other/Breakdown.stories.js
+++ b/src/stories/Other/Breakdown.stories.js
@@ -6,6 +6,7 @@ const BreakdownStories = {
     component: Breakdown,
     parameters: {
         design: {
+            name: "Figma",
             type: "figma",
             url: "https://www.figma.com/file/EFmxLREOeGUse5zksD3iT4/%E2%9A%99%EF%B8%8F-02---DS-Application-UI?node-id=236%3A144618&viewport=-3895%2C-275%2C0.33",
         },

--- a/src/stories/Other/HeaderToolbar.stories.js
+++ b/src/stories/Other/HeaderToolbar.stories.js
@@ -6,6 +6,7 @@ const HeaderToolbarStories = {
     component: HeaderToolbar,
     parameters: {
         design: {
+            name: "Figma",
             type: "figma",
             url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=7839%3A479666&viewport=5274%2C-3037%2C0.55",
         },

--- a/src/stories/Other/HeaderToolbar.stories.js
+++ b/src/stories/Other/HeaderToolbar.stories.js
@@ -4,6 +4,12 @@ import { Breadcrumb, Button, HeaderToolbar } from "../..";
 const HeaderToolbarStories = {
     title: "Other/Header Toolbars",
     component: HeaderToolbar,
+    parameters: {
+        design: {
+            type: "figma",
+            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=7839%3A479666&viewport=5274%2C-3037%2C0.55",
+        },
+    },
 };
 
 export const HeaderToolbars = () => {

--- a/src/stories/Other/Search.stories.js
+++ b/src/stories/Other/Search.stories.js
@@ -6,6 +6,7 @@ const SearchStories = {
     title: "Other/Search",
     parameters: {
         design: {
+            name: "Figma",
             type: "figma",
             url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=7839%3A479666&viewport=6893%2C-4568%2C0.71",
         },

--- a/src/stories/Other/Search.stories.js
+++ b/src/stories/Other/Search.stories.js
@@ -4,6 +4,12 @@ import { Search } from "../..";
 
 const SearchStories = {
     title: "Other/Search",
+    parameters: {
+        design: {
+            type: "figma",
+            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=7839%3A479666&viewport=6893%2C-4568%2C0.71",
+        },
+    },
 };
 
 const fetchUsers = async (search) => {

--- a/src/stories/Overlay/Drawer.stories.js
+++ b/src/stories/Overlay/Drawer.stories.js
@@ -10,6 +10,11 @@ const DrawerStories = {
                 component: "The Drawer component is a dynamic sidebar that is used to show data on the right side",
             },
         },
+        design: {
+            name: "Figma",
+            type: "figma",
+            url: "https://www.figma.com/file/YCbs6YcoYUNYGq9VhrEFQ0/13-Admin?node-id=960%3A27700&viewport=1028%2C673%2C0.38",
+        },
     },
     argTypes: {
         open: {

--- a/src/stories/Overlay/Modal.stories.js
+++ b/src/stories/Overlay/Modal.stories.js
@@ -11,6 +11,7 @@ const ModalStories = {
     },
     parameters: {
         design: {
+            name: "Figma",
             type: "figma",
             url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=7751%3A525089&viewport=6332%2C-1512%2C0.29",
         },

--- a/src/stories/Overlay/Modal.stories.js
+++ b/src/stories/Overlay/Modal.stories.js
@@ -9,6 +9,12 @@ const ModalStories = {
         shouldCloseOnOutsideClick: true,
         isOpen: false,
     },
+    parameters: {
+        design: {
+            type: "figma",
+            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=7751%3A525089&viewport=6332%2C-1512%2C0.29",
+        },
+    },
     argTypes: {
         size: {
             type: { required: false },

--- a/src/stories/Overlay/PopoverList.stories.js
+++ b/src/stories/Overlay/PopoverList.stories.js
@@ -38,6 +38,11 @@ const PopoverStories = {
                     "Render a list of items with icons in the Popover. All other arguments are not documented here because they are same as **Popover**",
             },
         },
+        design: {
+            name: "Figma",
+            type: "figma",
+            url: "https://www.figma.com/file/EFmxLREOeGUse5zksD3iT4/%E2%9A%99%EF%B8%8F-02---DS-Application-UI?node-id=220%3A189753",
+        },
     },
 };
 

--- a/src/stories/Overlay/Tooltip.stories.js
+++ b/src/stories/Overlay/Tooltip.stories.js
@@ -18,6 +18,13 @@ const TooltipStories = {
         offset: [0, 10],
         zIndex: 9999,
     },
+    parameters: {
+        design: {
+            name: "Figma",
+            type: "figma",
+            url: "https://www.figma.com/file/tL2vrxuBIzujkDfYvVjUhs/%E2%9A%99%EF%B8%8F-01---DS-Core?node-id=7683%3A478826&viewport=7035%2C-4414%2C0.57",
+        },
+    },
     argTypes: {
         content: getArgument("My tooltip text", "text", null, "The text of the tooltip"),
         trigger: getArgument(

--- a/src/stories/Screens/Login.stories.js
+++ b/src/stories/Screens/Login.stories.js
@@ -10,6 +10,11 @@ const LoginStories = {
                 component: "A default login screen specifically for Xola",
             },
         },
+        design: {
+            name: "Figma",
+            type: "figma",
+            url: "https://www.figma.com/file/loaaBJLNhy9ipQe3HW5wIn/14---Login?node-id=2%3A12437",
+        },
     },
     args: {
         backgroundType: "default",


### PR DESCRIPTION
Added the Storybook design add-on that allows you to add links to Figma in the storybook. All our Figma designs are protected so only authorised people will be able to see them anyways

**Preview URL:** https://636faa83d5278745f0080e09-avmlnztgrj.chromatic.com/?path=/story/data-display-alerts-banners--default

There is a more ["complex" integration from Storybook](https://www.figma.com/community/plugin/1056265616080331589/Storybook-Connect) itself but that requires a lot more close integration with design team that we don't have time for right now.