### PR TITLE
Do not checkout & run workflow if user is not in Xola

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -3,11 +3,11 @@ name: Lint
 on:
   push:
   # Runs against the workflow and code from the merge commit
-  pull_request:
-     types: [ opened, synchronize, reopened ]
+  # pull_request:
+  #   types: [ opened, synchronize, reopened ]
   # Runs against the workflow and code from the base of the pull request
-  # pull_request_target:
-  #   types: [opened, synchronize, reopened]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 env:
   DISABLE_PROGRESS: true
@@ -17,7 +17,6 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  pull-requests: write
   checks: write
   
 jobs:
@@ -26,6 +25,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check user for team affiliation
+        uses: tspascoal/get-user-teams-membership@v2
+        id: checkUserMember
+        with:
+          GITHUB_TOKEN: ${{ secrets.ES_LINT_TOKEN }}
+          username: ${{ github.actor }}
+          organization: xola
+          team: 'Engineering,X2 Consultants'
+    
+      - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
+        run: |
+          echo "Hey ${{ github.actor }} you are not in a whitelisted team"
+          exit 1
+
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is so that Xola team members can run the workflow from
`ataylorme/eslint-annotate-action@2.2.0` that writes to checks and
pull requests. This needs `pull_request_target` because for public repos
Github does not give write access to secrets.GITHUB_TOKEN and for some
reason giving a PT to the `eslint-annotate-action` workflow does not
work.

If we changed the default to `pull_request_target` this will allow
any user to run code in Github actions potentially giving them write
access
