### PR TITLE
Add test IDs for Google Places Autocomplete input and options

### DIFF
--- a/src/components/GooglePlacesAutocomplete.jsx
+++ b/src/components/GooglePlacesAutocomplete.jsx
@@ -130,6 +130,7 @@ export const GooglePlacesAutocomplete = ({ initialValue, onSelect, apiBaseUrl, r
     return (
         <div ref={dropdownRef} className="relative">
             <Input
+                data-testid="google-places-input"
                 type="text"
                 role="combobox"
                 aria-expanded={showDropdown}
@@ -155,6 +156,7 @@ export const GooglePlacesAutocomplete = ({ initialValue, onSelect, apiBaseUrl, r
                     ) : (
                         suggestions.map((suggestion, index) => (
                             <div
+                                data-testid="google-places-option"
                                 key={suggestion.place_id}
                                 className="flex cursor-pointer flex-col gap-2 border-b border-gray bg-white px-3 py-2 hover:bg-gray-light hover:text-blue-light"
                                 onClick={() => handleSelect(suggestion)}

--- a/src/components/GooglePlacesAutocomplete.jsx
+++ b/src/components/GooglePlacesAutocomplete.jsx
@@ -156,8 +156,8 @@ export const GooglePlacesAutocomplete = ({ initialValue, onSelect, apiBaseUrl, r
                     ) : (
                         suggestions.map((suggestion, index) => (
                             <div
-                                data-testid="google-places-option"
                                 key={suggestion.place_id}
+                                data-testid="google-places-option"
                                 className="flex cursor-pointer flex-col gap-2 border-b border-gray bg-white px-3 py-2 hover:bg-gray-light hover:text-blue-light"
                                 onClick={() => handleSelect(suggestion)}
                                 onMouseEnter={() => setActiveSuggestionIndex(index)}


### PR DESCRIPTION
This pull request adds test IDs to the `GooglePlacesAutocomplete` component to improve testability. Specifically, it introduces `data-testid` attributes to the input field and each suggestion option, making it easier to select these elements in automated tests.

Testability improvements:

* Added `data-testid="google-places-input"` to the input field in `GooglePlacesAutocomplete` for easier test targeting.
* Added `data-testid="google-places-option"` to each suggestion option in `GooglePlacesAutocomplete` to support more robust test selection.