### PR TITLE
feat(QW-245): Add WebP to default accepted image formats

### DIFF
--- a/src/components/ImageUpload.jsx
+++ b/src/components/ImageUpload.jsx
@@ -11,7 +11,7 @@ export const ImageUpload = ({
     hasDelete = true,
     requirements = null,
     caption = null,
-    csvAcceptFormats = "image/png,image/jpeg",
+    csvAcceptFormats = "image/png,image/jpeg,image/webp",
     onChange,
     onDelete,
     onError,
@@ -99,7 +99,7 @@ export const ImageUpload = ({
                         requirements
                     ) : (
                         <div>
-                            Check that the image is in PNG or JPG format
+                            Check that the image is in PNG, JPG or WebP format
                             {maxSize ? ` and does not exceed ${maxSize}MB` : ""}
                         </div>
                     )}


### PR DESCRIPTION
## Root Cause

The `ImageUpload` component had `csvAcceptFormats` defaulting to `image/png,image/jpeg`, which excluded WebP from the browser file picker. Hint text said "PNG or JPG format only" — no mention of WebP.

## Solution

- Updated default `csvAcceptFormats` prop: `image/png,image/jpeg` → `image/png,image/jpeg,image/webp`
- Updated hint text: "PNG or JPG format" → "PNG, JPG or WebP format"

This is an additive, non-breaking change. Consumers that already pass `csvAcceptFormats` explicitly are unaffected.

Closes [QW-245](https://xola01.atlassian.net/browse/QW-245)

[QW-245]: https://xola01.atlassian.net/browse/QW-245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ