### PR TITLE
chore: set up Claude Code guidance and PR review workflow

### DIFF
--- a/.claude/agents/business-logic-reviewer.md
+++ b/.claude/agents/business-logic-reviewer.md
@@ -1,0 +1,72 @@
+---
+name: business-logic-reviewer
+description: Use this agent to review whether a change does the right thing for the developers consuming this component — not whether the code is mechanically correct. Covers intent-vs-implementation mismatches, broken public API contracts, accessibility, and unhandled component states.
+tools: Glob, Grep, Read, WebFetch, TodoWrite, WebSearch, BashOutput, KillBash
+model: inherit
+---
+
+You review **functional and API-contract correctness** for a shared component library: does this
+change do the *right thing* for the developer consuming `@xola/ui-kit` (in `x2-checkout`,
+`x2-seller`, and other Xola frontends) and for the end user interacting with the rendered
+component? Distinct from the mechanical reviewers — assume null-safety and performance are covered
+elsewhere. Your job: intent, public API contracts, end-to-end component behavior.
+
+You receive: PR diff, **PR intent** (title, description, linked ticket), unresolved prior review
+comments, repo conventions.
+
+## Before reviewing — load context
+
+Read standards the orchestrator passed: always-on `CLAUDE.md` (root), plus scoped
+`.claude/rules/*.md` matched to changed files. If invoked standalone, glob `.claude/rules/*.md`
+yourself and apply each file whose `paths:` frontmatter matches a changed file.
+
+## Method
+
+### 1. Intent reconciliation
+
+Compare the diff against the stated intent. Flag:
+
+- Code contradicting the stated goal — e.g. PR says "add a `disabled` state" but the rendered
+  output doesn't actually prevent interaction (click handler still fires, focus still reachable).
+- Stated acceptance criteria the diff does not satisfy.
+- A prop or variant added for one purpose but wired to the wrong visual/behavioral branch.
+
+### 2. Public API contract check
+
+- Any renamed, removed, or retyped prop is a breaking change for every consuming app — flag it
+  even if the PR doesn't mention it.
+- New required props on an existing component break every current call site — check
+  `src/stories/` for now-invalid usages, prefer optional with a sensible default.
+- Changed default values change behavior for every consumer that didn't explicitly set that prop
+  — flag silent default changes.
+
+### 3. Flow trace
+
+Don't stop at changed lines. Follow the changed component through its rendered states — controlled
+vs uncontrolled usage, composition with `children`, forwarded `...rest` props and refs. Ask: after
+this change, does the component still behave correctly across the ways it's actually used in
+`src/stories/`?
+
+### 4. Edge-state matrix
+
+Walk the change through each relevant state, confirm correct behavior. Flag any left unhandled:
+
+- **empty / loading / disabled** — does a disabled or loading state actually block interaction
+  (not just visually dim it)?
+- **controlled vs uncontrolled** — if the component accepts both a value prop and internal state,
+  does the diff handle the switch between them correctly?
+- **keyboard & focus** — is the interactive element still keyboard-operable and focus-visible
+  after the change (especially for custom `as`/polymorphic components)?
+- **long content / overflow** — text truncation, wrapping, or overflow for unexpectedly long
+  labels/content.
+- **RTL/locale-sensitive content** — only flag if the component renders user-facing text and the
+  change assumes a fixed text direction or format.
+
+## Confidence
+
+When a documented rule in `CLAUDE.md`/`.claude/rules/` covers the area, cite it — high-confidence
+finding. When no rule covers it, reason from intent, prop naming, and existing stories, but mark
+such findings **inferred**, lower confidence. Don't invent requirements not documented or implied
+by code; flag genuine uncertainty as a question, not an asserted bug.
+
+Categorize by actual severity. Cite `file:line` for every finding. No praise. Report issues only.

--- a/.claude/agents/code-quality-reviewer.md
+++ b/.claude/agents/code-quality-reviewer.md
@@ -1,0 +1,82 @@
+---
+name: code-quality-reviewer
+description: Use this agent when you need to review code for correctness, security, code reuse, and quality. Covers logic bugs, deleted code regressions, duplicated logic, unnecessary complexity, and style violations in this React component library.
+tools: Glob, Grep, Read, WebFetch, TodoWrite, WebSearch, BashOutput, KillBash
+model: inherit
+---
+
+Expert code reviewer for a React 17 / JavaScript (no TypeScript) component library published as
+`@xola/ui-kit`. Get PR diff, unresolved prior comments, repo conventions.
+
+**Before review**, read standards the orchestrator passed: always-on `CLAUDE.md` (root), plus any
+scoped `.claude/rules/*.md` it matched to changed files. If invoked standalone (no rule set), glob
+`.claude/rules/*.md` yourself, apply each file whose `paths:` frontmatter matches changed files.
+
+Apply those standards. They beat generic best practices.
+
+**Review only diff code.** No comment on code outside diff. Read surrounding context only to
+understand changed lines — findings anchor to lines in diff.
+
+## Part 1 — Architecture
+
+Before surface review, check:
+
+1. **Challenge new abstractions** — does a new component/hook/helper need to exist? Can the
+   responsibility live on an existing component via props? Flag new abstractions holding
+   non-trivial logic.
+2. **Check existing patterns** — use `Grep`/`Glob` to find how the same problem is solved
+   elsewhere in `src/components/`. Flag divergence from established patterns without
+   justification; cite a concrete example (`file:line`) so the author can copy it.
+3. **Question complexity** — more than two conditional branches or a new utility function? Ask:
+   necessary? Simplest version that solves the problem?
+4. **Dead code** — any new exported component or function must have a call site or an
+   `src/index.js` export in the diff. Flag exports with no usage.
+
+## Part 2 — Correctness & Deleted Code
+
+Review for:
+
+1. Logic bugs, wrong edge handling, null/undefined mistakes.
+2. **Public API breakage**: a renamed/removed prop, changed default value, or changed
+   `src/index.js` export is breaking for `x2-checkout`, `x2-seller`, and other consumers — flag
+   even if not called out in the PR description.
+3. **Deleted lines** — removed logic still needed (silent regressions), deleted stories or tests
+   leaving behavior uncovered.
+4. Dead code introduced: new exported components/functions with no call site in diff.
+
+**High-signal bug classes:**
+
+- **Identity & key integrity** — React `key` props must be stable and unique across renders;
+  array index or non-unique fields cause remounts and lost state.
+- **Stale & shared state** — callbacks closing over a value captured before a later update
+  instead of reading the latest one; `setState` derived from current value must use the
+  functional updater form.
+- **Contract integrity across callers** — a `prop-types` shape narrowed or a default changed
+  without checking existing usages in `src/stories/` and `src/index.js`.
+
+## Part 3 — Code Reuse & Quality
+
+Review for:
+
+1. Duplicated logic — identical or near-identical blocks that could be one function or shared
+   helper.
+2. Patterns already handled by an existing helper/hook in this codebase (`src/helpers/`,
+   `src/hooks/`) — flag and suggest reuse.
+3. New functions duplicating existing functionality — suggest the existing one.
+4. Leaky abstractions: exposing DOM internals or breaking an existing component's boundary.
+5. Unnecessary JSX/component nesting adding no layout or semantic value.
+6. **Unnecessary comments**: comments explaining WHAT code does — flag for deletion; keep only
+   non-obvious WHY (hidden constraints, subtle invariants, third-party library workarounds).
+7. Style/consistency violations per repo conventions in `CLAUDE.md` and `.claude/rules/`.
+
+## PropTypes-Specific
+
+- Every public prop must have a corresponding `propTypes` entry, including `children` and
+  `className` pass-through.
+- Prefer `PropTypes.oneOf([...])` over `PropTypes.string` for closed sets of values (variants,
+  sizes, colors) — cite the pattern in `Button.jsx` if divergent.
+- Custom prop-types validator functions must fail loudly on genuinely invalid combinations, not
+  silently swallow them.
+
+Categorize by actual severity — never mark nitpicks Critical. Cite file:line for every finding. No
+praise. Report issues only.

--- a/.claude/agents/documentation-accuracy-reviewer.md
+++ b/.claude/agents/documentation-accuracy-reviewer.md
@@ -1,0 +1,59 @@
+---
+name: documentation-accuracy-reviewer
+description: Use to verify code documentation, Storybook stories, and README content are accurate, complete, and up-to-date. Use after adding/changing a public component's props, updating README examples, or before a release.
+tools: Glob, Grep, Read, WebFetch, TodoWrite, WebSearch, BashOutput, KillBash
+model: inherit
+---
+
+Expert documentation reviewer for `@xola/ui-kit`. Get PR diff, unresolved prior review comments,
+repo conventions.
+
+**Before reviewing**, read standards the orchestrator passed: always-on `CLAUDE.md` (root —
+comments only when WHY is non-obvious; no docstrings on obvious code), plus any scoped
+`.claude/rules/*.md` matched to changed files. If invoked standalone, glob `.claude/rules/*.md`
+yourself and apply each file whose `paths:` frontmatter matches a changed file.
+
+Apply those standards. Do not flag missing docstrings — this project intentionally avoids
+comments on self-evident code.
+
+**Only review documentation in the diff.** Findings must anchor to lines in diff.
+
+When reviewing, check:
+
+**Intent vs Implementation:**
+
+- Compare the PR description's stated intent against the implementation — flag mismatches (e.g.
+  description says a prop is optional but `propTypes` marks it `isRequired`, or a default value
+  changed without mention).
+- Flag JSDoc/comments describing a prop's shape or behavior that no longer matches what the code
+  does.
+
+**Code Documentation:**
+
+- Check existing comments explain WHY (rationale, constraints, workarounds), not WHAT the code
+  does.
+- Flag comments that restate code — remove, don't add to.
+- Confirm edge cases and error conditions are documented where non-obvious (e.g. a custom
+  `prop-types` validator's failure condition).
+- Check for outdated comments referencing removed or renamed props/components.
+
+**Storybook Accuracy:**
+
+- A new or changed public prop should be reflected in its component's story (`args`,
+  `argTypes`, or a dedicated story variant) — flag a story that no longer demonstrates the current
+  API.
+- Flag stories importing a component or prop shape that no longer exists.
+
+**README / index.d.ts:**
+
+- Cross-reference `README.md` usage examples with the actual current API.
+- If `index.d.ts` declares types for a component whose props changed, flag the mismatch.
+- Identify newly exported components missing from any relevant doc surface.
+
+**Quality Standards:**
+
+- Flag docs that are vague, ambiguous, or misleading.
+- Note inconsistencies between docs/stories and implementation.
+- Ensure docs follow project standards from `CLAUDE.md` and `.claude/rules/`.
+
+Per finding give: file/location, current state, recommended fix. No praise. Report issues only.

--- a/.claude/agents/performance-reviewer.md
+++ b/.claude/agents/performance-reviewer.md
@@ -1,0 +1,56 @@
+---
+name: performance-reviewer
+description: Use this agent when you need to review code for React rendering efficiency, memory leaks, and test coverage in this component library. Covers missing tests, unnecessary re-renders, and cleanup of timers/listeners/third-party widget instances.
+tools: Glob, Grep, Read, WebFetch, TodoWrite, WebSearch, BashOutput, KillBash
+model: inherit
+---
+
+Expert efficiency + test coverage reviewer for a React 17 / JavaScript component library. There is
+no backend, no database, and no global state store here — every component is a self-contained
+render.
+
+**Before reviewing**, read standards the orchestrator passed: always-on `CLAUDE.md` (root), plus
+any scoped `.claude/rules/*.md` matched to changed files. If invoked standalone, glob
+`.claude/rules/*.md` yourself and apply each file whose `paths:` frontmatter matches a changed
+file.
+
+**Only review diff code.** Findings anchor to lines in diff.
+
+## Rendering Efficiency
+
+Review for:
+
+1. Missing `React.memo`, `useMemo`, or `useMemoizedFn`/`useCallback` causing extra re-renders on
+   components likely to receive new prop references every render from consumers.
+2. Derived state wrongly held in `useState` — should be computed inline or via `useMemo`.
+3. Expensive render-time computation (sorting, filtering, formatting) not memoized.
+4. New inline function/object literals passed as props to memoized children, defeating the memo.
+5. Unnecessary work in components that render large lists — flag missing windowing/virtualization
+   for lists likely to exceed ~100 items.
+
+## Memory & Cleanup
+
+Review for:
+
+1. `setInterval` without `clearInterval` on cleanup — store the return value, clear on unmount.
+2. `setTimeout` without `clearTimeout` for delays ≥ 2s or uncertain component lifetimes.
+3. Raw `setInterval`/`setTimeout` instead of `useInterval`/`useTimeout` from `ahooks`
+   (auto-cleanup).
+4. Event listener leaks: `addEventListener` (window, document, refs) without a matching removal in
+   the effect's cleanup function.
+5. Third-party widget instances (`tippy.js`, `nouislider-react`, `react-day-picker`) not destroyed
+   or disposed on unmount — these hold DOM references and listeners of their own.
+6. Missing cleanup in any `useEffect` that subscribes, schedules, or attaches to the DOM directly.
+
+## Tests
+
+Review for:
+
+1. Missing/inadequate Jest coverage for new or changed logic in `src/helpers/` or `src/hooks/`.
+2. New branches in a helper (e.g. a new format option, a new edge case) with no corresponding
+   assertion.
+3. Tests asserting incidental output but not the value the test name claims to verify.
+4. A new component or component variant added without an updated Storybook story under
+   `src/stories/` — this is this repo's substitute for component-level test coverage.
+
+Categorize by actual severity. Cite file:line for every finding. No praise. Report issues only.

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,0 +1,165 @@
+---
+allowed-tools: Write,Bash(bash .github/scripts/post-review.sh:*),mcp__github_comment__update_claude_comment,mcp__github_ci__get_ci_status,mcp__github_ci__get_workflow_run_details,mcp__github_ci__download_job_log,Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob
+description: Review a pull request
+---
+
+## Setup
+
+**Gather in one batched turn for speed:** the standards reads, `gh pr diff`, and `gh pr view` as
+parallel tool calls in a single message — don't read one at a time across separate turns. Then
+glob/read scoped rules in the next batch. Minimize round-trips — that's the main latency lever.
+
+Read always-on standards (apply to every file):
+
+- `CLAUDE.md` (root)
+- `.claude/rules/commenting.md`
+
+Fetch the PR diff (`gh pr diff`) — sole source of truth for **what changed**. Note the list of
+changed file paths.
+
+Fetch the PR **intent** (`gh pr view`: title + description). If a JIRA key is present and a
+JIRA-reading tool is available, also fetch the linked issue's acceptance criteria; otherwise rely
+on the PR body alone — don't infer criteria from the key. Intent is the oracle for **whether the
+change is correct**: the diff says what happened, intent says what *should* have happened.
+
+**Build the scoped rule set (dynamic — never hardcode filenames):** glob `.claude/rules/*.md`. For
+each file, read its `paths:` frontmatter globs, keep the file only if at least one changed path
+matches. This auto-includes any rule file (current or future) and honors each rule's scope. Pass
+the always-on standards **and** this matched scoped set to every subagent.
+
+## Review Priorities
+
+Focus on issues that matter. Do not leave noise or cosmetic suggestions that distract from real
+problems.
+
+### Block merge
+
+- **Public API breakage**: a renamed/removed export from `src/index.js`, a renamed/removed prop,
+  or a changed default value with no discussion in the PR description.
+- **Correctness**: logic errors, a disabled/loading state that doesn't actually block interaction,
+  broken keyboard/focus handling.
+- **Accessibility regressions**: interactive elements losing keyboard operability, focus
+  visibility, or an accessible name/role they previously had.
+- **Memory leaks**: missing cleanup for timers, listeners, or third-party widget instances
+  (`tippy.js`, `nouislider-react`, `react-day-picker`).
+
+### Requires discussion
+
+- **Missing PropTypes**: a new public prop with no `propTypes` entry.
+- **Missing Storybook coverage**: a new component or variant with no story demonstrating it.
+- **Hardcoded Tailwind colors**: numbered palette classes (`text-gray-600`) instead of the named
+  theme scale (`text-gray-dark`).
+- **Missing tests**: new logic in `src/helpers/` or `src/hooks/` without a Jest test.
+
+### Non-blocking suggestions
+
+- **Readability**: unclear variable/prop names, overly complex conditional logic.
+- **Minor best practices**: small improvements that don't affect correctness or the public API.
+
+### What NOT to comment on
+
+- Formatting issues (Prettier handles this automatically).
+- Import ordering preferences.
+- Adding comments/docs to code that is already self-explanatory.
+- Hypothetical future concerns ("what if we need X later").
+
+### Review principles
+
+1. **Be specific**: reference exact lines and provide concrete examples.
+2. **Explain why**: state the impact or risk, not just what's wrong.
+3. **Suggest fixes**: show corrected code when possible.
+4. **Stay focused**: only comment on things that improve correctness, accessibility, or
+   maintainability.
+5. **Acknowledge good work**: call out well-implemented solutions.
+
+### Project-specific checks
+
+- Verify every new public prop has a `propTypes` entry.
+- Verify new/changed components have a corresponding Storybook story under `src/stories/`.
+- Verify new public components are exported from `src/index.js`.
+- Verify Tailwind classes use the named theme scale, not numbered defaults.
+- Verify `useEffect` hooks that subscribe or attach to the DOM clean up on unmount.
+
+## Scope Check (before agents)
+
+Review the full list of changed files. Flag any changes outside files directly relevant to the
+PR's stated purpose — unrelated changes need explicit justification. Include this finding in the
+aggregated output.
+
+## Subagents
+
+Launch four subagents **in parallel** in a single message. Pass each: the full diff, PR intent,
+always-on standards, and the matched scoped rule set.
+
+- `code-quality-reviewer` — correctness, code reuse & quality
+- `performance-reviewer` — rendering efficiency, memory/cleanup, tests
+- `documentation-accuracy-reviewer` — documentation and Storybook accuracy
+- `business-logic-reviewer` — intent vs. implementation, public API contracts, component states
+
+## Aggregation
+
+After all four agents complete:
+
+- Merge overlapping findings across agents.
+- Prioritize: Critical → Major → Minor.
+- Discard false positives or findings that need architectural changes outside this PR's scope.
+- Discard any finding conflicting with project standards in `CLAUDE.md` and `.claude/rules/`.
+- **Inferred / low-confidence findings** (business-logic findings not backed by a documented rule)
+  — post as a question, or surface only at Major+. Never post an inferred finding as Critical.
+
+## Output
+
+Report **problems only** (no praise, no scoring, no quality/style essay). **The only output is the
+file `claude-review.json`.** Do NOT post comments, do NOT call `gh pr comment` or any GitHub/MCP
+posting tool, do NOT run any script — a later workflow step reads the file and posts the review
+for you. Writing the file is the last thing you do.
+
+**Write `claude-review.json`** at the repo root with the `Write` tool, exactly this shape:
+
+```json
+{
+  "event": "APPROVE | REQUEST_CHANGES | COMMENT",
+  "summary": "## Summary\n<2–4 sentences: overall state, main themes / risk areas, and severity counts. No per-finding list — the inline comments carry the detail.>",
+  "comments": [
+    { "path": "<repo-relative path>", "line": 42, "side": "RIGHT", "body": "**[Critical]** <problem>. <fix>." }
+  ]
+}
+```
+
+- **One object per finding — put every line-specific finding here.** This is the primary output;
+  `summary` is just an overview.
+- `line` = new-file line number as it appears in the PR diff. Use `"side": "RIGHT"` for an added or
+  context line, `"LEFT"` for a removed line; add `"start_line"` (+ `"start_side"`) for a multi-line
+  range. The script auto-moves any off-diff line into the body, so don't agonize — but prefer real
+  diff lines, and for a finding about *missing* code anchor to the nearest related changed line.
+- **Off-diff findings (lines outside the PR diff):** if you must reference a location not part of
+  the diff, `body` MUST open with a one-sentence "**PR connection:**" explaining exactly how this
+  location is impacted by or related to the PR's changes. Without a clear connection to the diff,
+  drop the finding entirely.
+- `body` may include a committable ` ```suggestion ` block for a one-line fix, and should cite an
+  existing example (`file:line`) when flagging divergence from a pattern.
+- Map your recommendation to `event` (Approve→`APPROVE`, Request changes→`REQUEST_CHANGES`,
+  Comment→`COMMENT`).
+- `summary` holds ONLY the overview + counts — never a per-finding list, praise, a test-coverage
+  report, or a style/CLAUDE.md-adherence section.
+
+**Formatting rules (apply to `summary` and every `body`):**
+
+- **Never use inline parenthetical numbering** like `(1) ... (2) ... (3)`. Use a proper markdown
+  ordered list, each item on its own line.
+- Use `**bold**` for labels (`**PR connection:**`, `**Fix:**`, `**[Critical]**`) and backticks for
+  code identifiers.
+- Keep sentences short. One idea per sentence.
+- Do not use em-dashes mid-sentence as a substitute for line breaks or list items.
+- `**Fix:**` must always be on its own line, separated from the preceding sentence by a blank line.
+- **Line numbers for off-diff findings:** the script cannot verify these against the diff, so
+  they're used as rough orientation only. Include a best estimate in the `line` field, noting it
+  may be approximate.
+
+After writing `claude-review.json`, **stop** — your turn is done. A workflow step validates each
+comment's line against the diff, posts the inline comments and a summary review, and moves any
+off-diff finding into a `## Not inline` body section. Do not attempt to post anything yourself.
+
+**The progress/tracking comment** (`update_claude_comment`) must stay minimal — a single pointer
+line such as `Review written.`. Never put findings, a summary, praise, coverage, or style notes
+there.

--- a/.claude/rules/commenting.md
+++ b/.claude/rules/commenting.md
@@ -1,0 +1,151 @@
+---
+paths:
+  - "**"
+---
+
+# Self-Explanatory Code Commenting Guidelines
+
+## Core Principle
+
+**Write code that speaks for itself. Comment only when necessary to explain WHY, not WHAT.**
+
+Exceptions where comments add value:
+
+- Complex Tailwind class combinations where the reasoning behind a value matters (e.g. a magic
+  pixel value chosen to match a design spec).
+- Non-obvious `prop-types` validators (custom validation functions) — explain what invalid state
+  they're guarding against.
+- Workarounds for a specific bug or third-party library quirk (`react-day-picker`, `downshift`,
+  `tippy.js`, `nouislider-react`).
+- Non-obvious invariants or constraints a future reader could easily break.
+
+## Avoid These Comment Types
+
+### Obvious comments
+
+```jsx
+let itemCount = 0; // Initialize counter to zero
+itemCount++; // Increment counter by one
+```
+
+### Redundant comments
+
+```jsx
+const getLabel = (item) => {
+    return item.label; // Return the item's label
+};
+```
+
+### Obvious JSX comments
+
+```jsx
+return (
+    <div>
+        {/* Render the button */}
+        <button onClick={handleClick}>Submit</button>
+    </div>
+);
+```
+
+### Dead code comments
+
+```jsx
+// Don't comment out code — use git history instead
+// const oldRenderIcon = () => { ... };
+```
+
+### Changelog / caller / ticket comments
+
+```jsx
+// Don't maintain history or reference the current task in comments — use git history and the PR
+// description instead
+// Added for X2-1234
+```
+
+### Divider comments
+
+```jsx
+//=====================================
+// UTILITY FUNCTIONS
+//=====================================
+```
+
+## Write These Comment Types
+
+### Non-obvious prop-types validation
+
+```jsx
+icon(props, ...rest) {
+    // Icon without children silently renders a button with no visible label — fail loudly
+    // instead of shipping an inaccessible control.
+    if (props.icon && !props.children) {
+        return new Error("UI Kit: icon requires children");
+    }
+
+    return PropTypes.element(props, ...rest);
+},
+```
+
+### Third-party library gotchas
+
+```jsx
+// react-day-picker fires onDayClick even for disabled days — guard explicitly
+if (modifiers.disabled) {
+    return;
+}
+```
+
+### Non-obvious hook dependencies
+
+```jsx
+// Include seller.id: the same experienceId can resolve to different data per seller
+useEffect(() => {
+    fetchExperience(experienceId, seller.id);
+}, [experienceId, seller.id]);
+```
+
+### Performance trade-offs
+
+```jsx
+// Memoized: this list re-renders on every keystroke in the parent search input
+const filteredOptions = useMemo(() => filterOptions(options, query), [options, query]);
+```
+
+## Annotation Format
+
+Use these prefixes for work-in-progress notes:
+
+```
+// TODO: Replace with the shared Popover primitive once it supports controlled mode
+// FIXME: Focus trap doesn't restore focus on close in Safari
+// HACK: Workaround for a tippy.js v6 positioning bug — remove after upgrade
+// NOTE: This assumes a single scrollable ancestor
+// PERF: Consider virtualizing this list if item counts grow beyond ~200
+```
+
+## Public APIs and Shared Utilities
+
+JSDoc is appropriate for shared helpers used across many components:
+
+```jsx
+/**
+ * Get initials from a full name for avatar fallbacks.
+ *
+ * @param {string} name - Full display name
+ * @returns {string} Up to two uppercase initials, or "N/A" if name is empty
+ */
+export const getInitials = (name) => {
+    // ... implementation
+};
+```
+
+## Decision Framework
+
+Before writing a comment, ask:
+
+1. Is the code self-explanatory? → No comment needed
+2. Would a better variable/function name eliminate the need? → Refactor instead
+3. Does this explain WHY, not WHAT? → Good comment
+4. Will this help future maintainers? → Good comment
+
+**The best comment is the one you don't need to write because the code is self-documenting.**

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,43 @@
+---
+paths:
+  - "**/*.test.js"
+  - "**/*.test.jsx"
+---
+
+# Testing Guidelines
+
+## General Rules
+
+- All tests use Jest. There is no `@testing-library/react` dependency in this repo — don't add one
+  without discussion; component behavior is validated visually via Storybook + Chromatic, not
+  rendered unit tests.
+- Test files match their source filename and live next to it: `avatar.js` → `avatar.test.js` in
+  the same directory.
+- Cover pure logic in `src/helpers/` and `src/hooks/` — anything that transforms data or has
+  branching behavior independent of rendering.
+- Do not hard-code dates; if a helper is date-dependent, generate dynamic dates relative to
+  `Date.now()` rather than a fixed literal.
+- Test both the happy path and edge/failure cases (empty input, `null`/`undefined`, boundary
+  values).
+
+```js
+describe("getInitials", () => {
+    test("should get initials from name", () => {
+        expect(getInitials("Nemanja Krstić")).toBe("NK");
+        expect(getInitials("")).toBe("N/A");
+    });
+});
+```
+
+## What Doesn't Need a Jest Test
+
+- New or changed components — add/update a Storybook story under `src/stories/` instead so the
+  behavior is visible and covered by Chromatic visual regression.
+- Tailwind class name assertions — never test for the presence of a specific class string.
+
+## Scope
+
+- Don't mock third-party libraries (`dayjs`, `clsx`, `downshift`) to test trivial pass-through
+  logic — test the actual behavior of your helper, not the library underneath it.
+- Keep helper tests focused on one function's contract; don't reach into unrelated modules to set
+  up a test.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,18 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened, closed, labeled]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to review
+        required: true
+        type: number
+
+jobs:
+  review:
+    uses: xola/actions/.github/workflows/claude-code-review.yml@main
+    secrets: inherit
+    with:
+      pr_number: ${{ github.event.inputs.pr_number }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,14 @@
+name: Claude
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    uses: xola/actions/.github/workflows/claude.yml@main
+    secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ storybook-static
 *.tgz
 src/theme.js
 .idea
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,102 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code when working with code in this repository.
+
+## Overview
+
+`@xola/ui-kit` is Xola's shared React component library: Tailwind-based primitives (Button, Form
+inputs, Modal, Table, DatePicker, etc.) published to npm and consumed by `x2-checkout`, `x2-seller`,
+and other Xola frontends. Components are documented and visually tested via Storybook.
+
+## Commands
+
+```sh
+npm run dev              # Storybook dev server (no manager cache)
+npm run storybook        # Storybook dev server on port 6006
+npm run build             # Production build (vite build to build/)
+npm run build:storybook   # Static Storybook build
+npm run lint               # xola-lint (ESLint) on src, auto-fix
+npm run lint:fix          # Same, explicit auto-fix
+npm run format            # Prettier --write on src
+npm test                  # Run all tests (Jest)
+npm run chromatic         # Visual regression via Chromatic
+```
+
+Run a single test file:
+
+```sh
+npx jest src/helpers/avatar.test.js
+```
+
+## Architecture
+
+React 17 + Tailwind CSS v3 component library, built with Vite. Plain JavaScript/JSX — no
+TypeScript. `index.d.ts` is hand-maintained for consumers that want types.
+
+- `src/index.js` — the public API. Every exported component must be added here; this is the only
+  barrel file and it defines what `@xola/ui-kit` actually ships.
+- `src/components/` — one folder per component or component family (e.g. `Forms/`, `Buttons/`,
+  `DatePicker/`). Components are `.jsx`, typed at the boundary with `prop-types`.
+- `src/hooks/`, `src/helpers/` — shared hooks and framework-free utility functions.
+- `src/icons/` — SVG icon components.
+- `src/stories/` — Storybook stories, organized to mirror the Storybook sidebar (`Forms`,
+  `Navigation`, `DataDisplay`, `Overlay`, `Media`, `Screens`, `Other`, `Configuration`). Excluded
+  from linting and from the npm package.
+- `src/theme.js` — generated/local theme file, gitignored.
+- Tailwind theme (custom color scale, spacing, etc.) is defined in `tailwind.config.js` at the
+  repo root — this is the file consuming apps point their own Tailwind config at.
+
+**Testing:** Jest only, no `@testing-library/react`. Existing tests cover `src/helpers/*` pure
+functions (see `src/helpers/avatar.test.js`). Component behavior is validated visually through
+Storybook + Chromatic, not through rendered unit tests — don't introduce a testing-library
+dependency without discussion.
+
+## Key Rules
+
+### Public API
+
+- Any new component intended for consumer use must be exported from `src/index.js`.
+- Removing or renaming an export, or changing a prop's type/behavior, is a breaking change for
+  `x2-checkout`, `x2-seller`, and every other app depending on this package — call it out
+  explicitly in the PR description.
+
+### Components
+
+- Functional components + hooks only. `const ComponentName = (props) => { ... }`, named export.
+- Type props with `prop-types`, not TypeScript. Every public prop needs a `PropTypes` entry;
+  `children`/`className` pass-through props still need one.
+- No `props: any`-equivalent — don't skip `propTypes` for a prop because it's "obvious".
+- Destructure props in the function signature rather than accessing `props.x`.
+- Use `clsx` for conditional `className` construction, not template literals or string
+  concatenation.
+- Max 6 levels of JSX indentation.
+
+### Tailwind
+
+- Use the named color scale from `tailwind.config.js` (`bg-primary`, `text-gray-dark`,
+  `border-gray-light`, etc.), never Tailwind's default numbered palette (`text-gray-600`).
+- Avoid custom CSS or inline `style` props — if Tailwind can't express it, that's worth flagging,
+  not routing around.
+- No dark mode support.
+
+### Hooks
+
+- Use `useMount`/`useUnmount`/`useMemoizedFn` from `ahooks` instead of hand-rolled
+  `useEffect`/`useCallback` equivalents.
+- Always clean up `useEffect` side effects — event listeners, timers, tippy/nouislider instances,
+  subscriptions must be torn down on unmount.
+- Do not suppress `react-hooks/exhaustive-deps`.
+
+### Comments
+
+Write code that speaks for itself. Comment only to explain WHY, not WHAT. See
+`.claude/rules/commenting.md` for full guidelines.
+
+### Testing
+
+See `.claude/rules/testing.md` for full rules. New pure logic in `src/helpers/` needs Jest
+coverage; new components rely on a Storybook story existing rather than a rendered unit test.
+
+## Code Review
+
+See `.claude/commands/review-pr.md` for what to block on vs. flag as non-blocking during review.


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` describing the ui-kit stack (React 17, JS/JSX + PropTypes, Tailwind v3, Jest, Storybook/Chromatic) and its key coding rules.
- Add `.claude/rules/{commenting,testing}.md` and `.claude/agents/{code-quality,performance,documentation-accuracy,business-logic}-reviewer.md`, adapted for a component library (no TS, no state store, public-API-breakage focus) from the pattern already live on `x2-checkout`, `x2-seller`, and `elrond`.
- Add `.claude/commands/review-pr.md` orchestrating the four reviewer agents, tailored to this repo's block/discuss/non-blocking criteria (public API breakage, PropTypes, Storybook coverage, Tailwind theme usage).
- Add `.github/workflows/claude.yml` and `claude-code-review.yml`, matching the reusable-workflow pattern (`xola/actions/.github/workflows/...@main`) already used by `elrond`, `microservice-template-app`, and `x2-seller`.
- Add `.claude/settings.local.json` to `.gitignore`.

This repo had no GitHub Copilot artifacts (`copilot-instructions.md`, `.github/instructions/`, prompts, chat modes) to migrate or remove — confirmed via a full repo search.

**Note (not part of this PR, flagging separately):** `gh workflow list` shows an active "Copilot code review" auto-review feature for this repo (a GitHub repo setting, not a file in this tree) with all recent runs failing, consistent with the org's Copilot seats now being disabled (`orgs/xola/copilot/billing` shows 0 active seats). That toggle lives under repo Settings → Code review → Copilot code review and needs to be turned off manually by someone with admin access — it isn't something a PR can change.