### PR TITLE
feat(BottomSheet): QW-267 add mobile bottom-sheet drawer component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ storybook-static
 src/theme.js
 .idea
 .claude/settings.local.json
+.codegraph

--- a/index.d.ts
+++ b/index.d.ts
@@ -266,6 +266,7 @@ export {
     UnlinkIcon,
     useId,
     useIsClient,
+    useIsMobile,
     useViewportHeight,
     UserAddIcon,
     UserChangedIcon,

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,6 +26,7 @@ export {
     BellIcon,
     BookIcon,
     BookmarkIcon,
+    BottomSheet,
     BoxIcon,
     BugIcon,
     Breadcrumb,

--- a/src/components/BottomSheet.jsx
+++ b/src/components/BottomSheet.jsx
@@ -5,6 +5,7 @@ import PropTypes from "prop-types";
 import React, { Fragment } from "react";
 import { isIosBrowser } from "../helpers/browser";
 import { useViewportHeight } from "../hooks/useViewportHeight";
+import { CloseIcon } from "../icons";
 
 // A mobile-first bottom sheet. Mirrors Modal's compound API (Header/Body/Footer) so it can be
 // swapped in wherever a Modal is used on small screens. Kept at z-30 (same as Modal) so popovers
@@ -66,10 +67,17 @@ export const BottomSheet = ({
                         style={panelStyle}
                         className={clsx(
                             className,
-                            "ui-bottom-sheet-panel fixed inset-x-0 bottom-0 flex max-h-[90dvh] w-full flex-col rounded-t-2xl bg-white px-6 pb-8 pt-3 text-left shadow-xl",
+                            "ui-bottom-sheet-panel fixed inset-x-0 bottom-0 flex max-h-[90dvh] w-full flex-col rounded-t-2xl bg-white px-6 pb-8 pt-6 text-left shadow-xl",
                         )}
                     >
-                        <div className="mx-auto mb-4 h-1.5 w-10 shrink-0 rounded-full bg-gray" aria-hidden="true" />
+                        <button
+                            type="button"
+                            aria-label="Close"
+                            className="absolute right-4 top-4 z-10 p-1 text-black hover:text-gray-darker"
+                            onClick={() => onClose()}
+                        >
+                            <CloseIcon />
+                        </button>
 
                         {children}
                     </div>
@@ -87,9 +95,14 @@ BottomSheet.propTypes = {
     className: PropTypes.string,
 };
 
+// px-8 keeps the centered title clear of the absolute close button in the top-right corner.
 const Header = ({ children, description, className, ...rest }) => {
     return (
-        <Dialog.Title as="div" className={clsx(className, "ui-bottom-sheet-header shrink-0 text-center")} {...rest}>
+        <Dialog.Title
+            as="div"
+            className={clsx(className, "ui-bottom-sheet-header shrink-0 px-8 text-center")}
+            {...rest}
+        >
             <h3 className="text-2xl font-semibold leading-6 text-black">{children}</h3>
 
             {description ? (

--- a/src/components/BottomSheet.jsx
+++ b/src/components/BottomSheet.jsx
@@ -1,0 +1,138 @@
+import { Dialog, Transition } from "@headlessui/react";
+import clsx from "clsx";
+import { noop } from "lodash";
+import PropTypes from "prop-types";
+import React, { Fragment } from "react";
+import { isIosBrowser } from "../helpers/browser";
+import { useViewportHeight } from "../hooks/useViewportHeight";
+
+// A mobile-first bottom sheet. Mirrors Modal's compound API (Header/Body/Footer) so it can be
+// swapped in wherever a Modal is used on small screens. Kept at z-30 (same as Modal) so popovers
+// that portal to document.body (DatePicker calendar at z-40, ComboBox menu at z-30) stack above it.
+export const BottomSheet = ({
+    isOpen = false,
+    // Configurable: when true, tapping the dark overlay closes the sheet. Default false keeps parity
+    // with Modal. Closing is wired to the overlay's own onClick (not the Dialog's built-in
+    // outside-click) so interacting with popovers portaled outside the sheet — the DatePicker
+    // calendar, the ComboBox menu — is never mistaken for an outside click.
+    shouldCloseOnOutsideClick = false,
+    onClose,
+    children,
+    className,
+}) => {
+    const viewportHeight = useViewportHeight();
+    const isIOS = isIosBrowser();
+
+    const handleOverlayClick = () => {
+        if (shouldCloseOnOutsideClick) {
+            onClose();
+        }
+    };
+
+    // iOS mobile browsers report an unreliable `vh`/`dvh` (collapsing address bar), so cap the sheet
+    // by the measured innerHeight there. Other browsers use `dvh` via the class below. Guarded on a
+    // non-zero height so the panel doesn't briefly render at 0 height and jump on mount.
+    const panelStyle = isIOS && viewportHeight ? { maxHeight: `${Math.round(viewportHeight * 0.9)}px` } : undefined;
+
+    return (
+        <Transition appear show={isOpen} as={Fragment}>
+            <Dialog as="div" className="ui-bottom-sheet fixed inset-0 z-30" onClose={noop}>
+                <Transition.Child
+                    as={Fragment}
+                    enter="ease-out duration-300"
+                    enterFrom="opacity-0"
+                    enterTo="opacity-100"
+                    leave="ease-in duration-200"
+                    leaveFrom="opacity-100"
+                    leaveTo="opacity-0"
+                >
+                    <div
+                        className="ui-bottom-sheet-overlay fixed inset-0 bg-black bg-opacity-80 transition-opacity"
+                        aria-hidden="true"
+                        onClick={handleOverlayClick}
+                    />
+                </Transition.Child>
+
+                <Transition.Child
+                    as={Fragment}
+                    enter="transform transition ease-out duration-300"
+                    enterFrom="translate-y-full"
+                    enterTo="translate-y-0"
+                    leave="transform transition ease-in duration-200"
+                    leaveFrom="translate-y-0"
+                    leaveTo="translate-y-full"
+                >
+                    <div
+                        style={panelStyle}
+                        className={clsx(
+                            className,
+                            "ui-bottom-sheet-panel fixed inset-x-0 bottom-0 flex max-h-[90dvh] w-full flex-col rounded-t-2xl bg-white px-6 pb-8 pt-3 text-left shadow-xl",
+                        )}
+                    >
+                        <div className="mx-auto mb-4 h-1.5 w-10 shrink-0 rounded-full bg-gray" aria-hidden="true" />
+
+                        {children}
+                    </div>
+                </Transition.Child>
+            </Dialog>
+        </Transition>
+    );
+};
+
+BottomSheet.propTypes = {
+    isOpen: PropTypes.bool.isRequired,
+    shouldCloseOnOutsideClick: PropTypes.bool,
+    onClose: PropTypes.func.isRequired,
+    children: PropTypes.node.isRequired,
+    className: PropTypes.string,
+};
+
+const Header = ({ children, description, className, ...rest }) => {
+    return (
+        <Dialog.Title as="div" className={clsx(className, "ui-bottom-sheet-header shrink-0 text-center")} {...rest}>
+            <h3 className="text-2xl font-semibold leading-6 text-black">{children}</h3>
+
+            {description ? (
+                <p className="mt-2 text-base font-normal leading-normal text-gray-darker">{description}</p>
+            ) : null}
+        </Dialog.Title>
+    );
+};
+
+Header.propTypes = {
+    children: PropTypes.node.isRequired,
+    description: PropTypes.string,
+    className: PropTypes.string,
+};
+
+Header.displayName = "BottomSheet.Header";
+BottomSheet.Header = Header;
+
+// The body hugs its content so short sheets stay short (no `flex-1`/grow). `min-h-0` lets it shrink
+// below its content and scroll when the content would otherwise push the sheet past `max-h-[90dvh]`,
+// keeping the footer pinned and visible. So: short content → short sheet, tall content → scrolls.
+const Body = ({ className, ...rest }) => {
+    return <div className={clsx(className, "ui-bottom-sheet-body mt-6 min-h-0 overflow-y-auto")} {...rest} />;
+};
+
+Body.propTypes = {
+    className: PropTypes.string,
+};
+
+Body.displayName = "BottomSheet.Body";
+BottomSheet.Body = Body;
+
+// Footer actions stretch full width and sit side-by-side per the mobile design, unlike Modal's
+// right-aligned footer. The `[&>*]:flex-1` arbitrary variant gives each button equal width.
+const Footer = ({ className, ...rest }) => {
+    return (
+        <div className={clsx(className, "ui-bottom-sheet-footer mt-6 flex shrink-0 gap-3 [&>*]:flex-1")} {...rest} />
+    );
+};
+
+Footer.propTypes = {
+    className: PropTypes.string,
+};
+
+Footer.displayName = "BottomSheet.Footer";
+BottomSheet.Footer = Footer;

--- a/src/components/DatePicker/DatePicker.css
+++ b/src/components/DatePicker/DatePicker.css
@@ -276,3 +276,53 @@
 .DayPicker-Day.DayPicker-Day--waitlist > div::after {
     @apply absolute bottom-1 h-2 w-2 rounded-full bg-yellow content-[''];
 }
+
+/**
+ * Mobile: the calendar's desktop sizing (400px min-width, 48px priced cells, 16px row gaps) is
+ * far too big for a phone — inside the traveler bottom sheet the bottom weeks overflow below the
+ * viewport. Below the `md` breakpoint, drop the min-width and tighten cells/row spacing so the
+ * whole month fits. Seller is a desktop dashboard and never hits this breakpoint.
+ */
+@media (max-width: 767px) {
+    .DayPicker-Month {
+        min-width: auto;
+    }
+
+    .has-custom-content .DayPicker-Month {
+        border-spacing: 1px 2px;
+    }
+
+    .has-custom-content .DayPicker-Day .ui-day-content,
+    .has-custom-content .DayPicker-Day .ui-day-content:hover,
+    .has-custom-content .DayPicker-Day .ui-date-picker-day,
+    .has-custom-content .DayPicker-Day:hover .ui-date-picker-day {
+        @apply h-9 w-9;
+    }
+
+    .has-custom-content .DayPicker-Day .ui-day-content-custom {
+        @apply text-[10px] leading-none;
+    }
+
+    /* The desktop `pl-3` per cell adds 12px × 7 columns = 84px, overflowing the phone width and
+       clipping the Saturday column. Trim it so the 7-column grid fits within the viewport. */
+    .DayPicker-Day {
+        @apply !pl-1;
+    }
+
+    /* Trim the popover's own padding (desktop is p-6 / pt-6) so the calendar isn't ringed by wide
+       empty margins on a phone. */
+    .ui-date-picker-input {
+        @apply !p-3;
+    }
+
+    .ui-date-picker {
+        @apply !pt-3;
+    }
+
+    /* The "Today" button is absolutely positioned into the caption row (right-24); on the narrow
+       mobile calendar it collides with the year <select>. Hide it on mobile — the nav arrows and
+       month/year selects still cover navigation — which also reclaims vertical space. */
+    .DayPicker-TodayButton {
+        display: none;
+    }
+}

--- a/src/components/DatePicker/DatePickerPopover.jsx
+++ b/src/components/DatePicker/DatePickerPopover.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import React, { cloneElement, forwardRef, useEffect, useState } from "react";
 import { CalendarIcon, DownArrowIcon } from "../..";
 import { formatDate } from "../../helpers/date";
+import { useIsMobile } from "../../hooks/useIsMobile";
 import { Input } from "../Forms/Input";
 import { Popover } from "../Popover/Popover";
 import { DatePicker } from "./DatePicker";
@@ -57,6 +58,12 @@ export const DatePickerPopover = ({
         setOriginalValue(value);
     }, [value]);
 
+    // On mobile the calendar is tall relative to the viewport; opening it downward (below the
+    // input) runs it off the bottom of the screen — especially inside a bottom sheet, and worse
+    // behind the mobile browser's toolbar. Force it to open upward into the roomier space above the
+    // field. This deliberately overrides any consumer-supplied `placement` on mobile only.
+    const isMobile = useIsMobile();
+
     return (
         <Popover
             visible={isVisible}
@@ -66,6 +73,7 @@ export const DatePickerPopover = ({
             className={clsx("ui-date-picker-input", classNames.popover)}
             onClickOutside={handleClickOutside}
             {...popoverProps}
+            {...(isMobile ? { placement: "top", distance: 4 } : {})}
         >
             {children ? (
                 cloneElement(children, { onClick: toggleVisibility })

--- a/src/hooks/useIsMobile.js
+++ b/src/hooks/useIsMobile.js
@@ -1,0 +1,11 @@
+import { useResponsive } from "ahooks";
+
+/**
+ * True when the viewport is below the `md` breakpoint (< 768px) — i.e. mobile web. Mirrors the
+ * Tailwind `md` breakpoint so JS mobile checks stay in sync with responsive CSS, and reacts to
+ * resize / orientation change (unlike a one-off `window.matchMedia` read).
+ */
+export const useIsMobile = () => {
+    const responsive = useResponsive();
+    return !responsive?.md;
+};

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ export { Tooltip } from "./components/Tooltip";
 export { Popover } from "./components/Popover/Popover";
 export { PopoverList } from "./components/Popover/PopoverList";
 export { Modal } from "./components/Modal";
+export { BottomSheet } from "./components/BottomSheet";
 export { Table } from "./components/Table";
 export { ButtonGroup } from "./components/Buttons/ButtonGroup";
 export { Counter } from "./components/Counter";

--- a/src/index.js
+++ b/src/index.js
@@ -63,6 +63,7 @@ export { flash } from "./helpers/flash";
 
 // Hooks
 export { useId } from "./hooks/useId";
+export { useIsMobile } from "./hooks/useIsMobile";
 
 // Chart options
 export { BaseChartOptions } from "./components/Charts/BaseChartOptions";

--- a/src/stories/DataDisplay/DatePicker.stories.js
+++ b/src/stories/DataDisplay/DatePicker.stories.js
@@ -172,18 +172,12 @@ addDescription(
     "This example shows how to use the `month` and `shouldShowYearPicker` prop to change the calendar's caption. For example, we can use these props to start in the month of April and to add a form to switch between months and years.",
 );
 
-
 export const SelectMonth = () => {
     const [value, setValue] = useState(new Date());
     return (
         <div className="space-y-2">
             <div>Date: {value.toDateString()}</div>
-            <DatePicker
-                shouldShowMonthSelector
-                value={value}
-                month={new Date(2023, 3, 21)}
-                onChange={setValue}
-            />
+            <DatePicker shouldShowMonthSelector value={value} month={new Date(2023, 3, 21)} onChange={setValue} />
         </div>
     );
 };
@@ -197,7 +191,7 @@ export const MonthPickerPopover = () => {
     const [value, setValue] = useState(new Date());
     return (
         <div className="h-75 w-75">
-            <DatePickerPopover pickerType="month" dateFormat="MMM YYYY"  value={value} onChange={setValue}  />
+            <DatePickerPopover pickerType="month" dateFormat="MMM YYYY" value={value} onChange={setValue} />
         </div>
     );
 };

--- a/src/stories/Other/Breakdown.stories.js
+++ b/src/stories/Other/Breakdown.stories.js
@@ -46,7 +46,13 @@ export const Default = () => {
                     Payment
                 </Breakdown.Item>
 
-                <Breakdown.Item color="primary" info="*0259" secondary="07/23/2021" value={-62} methodIcon={<CardIcon />}>
+                <Breakdown.Item
+                    color="primary"
+                    info="*0259"
+                    secondary="07/23/2021"
+                    value={-62}
+                    methodIcon={<CardIcon />}
+                >
                     Return Payment
                 </Breakdown.Item>
 

--- a/src/stories/Overlay/BottomSheet.stories.js
+++ b/src/stories/Overlay/BottomSheet.stories.js
@@ -1,0 +1,57 @@
+import React, { useState } from "react";
+import { BottomSheet, Button, Input } from "../..";
+
+const BottomSheetStories = {
+    title: "Overlay/BottomSheet",
+    component: BottomSheet,
+    args: {
+        shouldCloseOnOutsideClick: true,
+        isOpen: false,
+    },
+    argTypes: {
+        shouldCloseOnOutsideClick: {
+            type: { required: false },
+            description: "Close the sheet if user clicks the overlay",
+            control: { type: "boolean" },
+        },
+        isOpen: {
+            type: { required: false },
+            description: "Control the sheet open state",
+            control: { type: "boolean" },
+        },
+    },
+};
+
+export const Default = ({ shouldCloseOnOutsideClick }) => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    const toggle = () => {
+        setIsOpen(!isOpen);
+    };
+
+    return (
+        <div>
+            <Button onClick={toggle}>Click me to launch a bottom sheet</Button>
+
+            <BottomSheet isOpen={isOpen} shouldCloseOnOutsideClick={shouldCloseOnOutsideClick} onClose={toggle}>
+                <BottomSheet.Header description="Enter the code below to apply the code">Apply Code</BottomSheet.Header>
+
+                <BottomSheet.Body>
+                    <Input placeholder="Coupon or Affiliate" />
+                </BottomSheet.Body>
+
+                <BottomSheet.Footer>
+                    <Button color="secondary" variant="outline" onClick={toggle}>
+                        Cancel
+                    </Button>
+
+                    <Button color="primary" onClick={toggle}>
+                        Confirm
+                    </Button>
+                </BottomSheet.Footer>
+            </BottomSheet>
+        </div>
+    );
+};
+
+export default BottomSheetStories;

--- a/src/stories/Overlay/BottomSheet.stories.js
+++ b/src/stories/Overlay/BottomSheet.stories.js
@@ -1,5 +1,6 @@
+import dayjs from "dayjs";
 import React, { useState } from "react";
-import { BottomSheet, Button, Input } from "../..";
+import { BottomSheet, Button, DatePickerPopover, Input } from "../..";
 
 const BottomSheetStories = {
     title: "Overlay/BottomSheet",
@@ -47,6 +48,123 @@ export const Default = ({ shouldCloseOnOutsideClick }) => {
 
                     <Button color="primary" onClick={toggle}>
                         Confirm
+                    </Button>
+                </BottomSheet.Footer>
+            </BottomSheet>
+        </div>
+    );
+};
+
+// Tall scrollable body: the Body scrolls independently while the Header/Footer stay pinned.
+export const ScrollableContent = ({ shouldCloseOnOutsideClick }) => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    const toggle = () => {
+        setIsOpen(!isOpen);
+    };
+
+    return (
+        <div>
+            <Button onClick={toggle}>Click me to launch a scrollable bottom sheet</Button>
+
+            <BottomSheet isOpen={isOpen} shouldCloseOnOutsideClick={shouldCloseOnOutsideClick} onClose={toggle}>
+                <BottomSheet.Header>Terms &amp; Conditions</BottomSheet.Header>
+
+                <BottomSheet.Body>
+                    {Array.from({ length: 30 }).map((_, index) => (
+                        // eslint-disable-next-line react/no-array-index-key
+                        <p key={index} className="mb-4">
+                            Paragraph {index + 1}: the body scrolls independently while the header and footer stay
+                            pinned.
+                        </p>
+                    ))}
+                </BottomSheet.Body>
+
+                <BottomSheet.Footer>
+                    <Button color="primary" onClick={toggle}>
+                        Accept
+                    </Button>
+                </BottomSheet.Footer>
+            </BottomSheet>
+        </div>
+    );
+};
+
+// Priced day content — reproduces the traveler calendar's `has-custom-content` layout (larger day
+// cells + a price under each date), which is what makes the calendar tall enough to overflow a
+// phone before the mobile size fix in DatePicker.css.
+const getPricedDayContent = (date) => {
+    const dayOfMonth = dayjs(date).date();
+    return <span className="text-xs text-gray-dark">${dayOfMonth % 3 === 0 ? 22 : 27}</span>;
+};
+
+// Mirrors the traveler "Change Arrival" modal — a tall sheet with an item summary, a date field
+// whose (large, priced) calendar opens in a popover, time slots, and a purchase summary. Verifies
+// (a) the calendar stacks ABOVE the sheet (z-40 popover vs z-30 sheet) rather than being hidden,
+// and (b) the calendar fits on a phone instead of overflowing below the viewport.
+export const WithDatePicker = ({ shouldCloseOnOutsideClick }) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [date, setDate] = useState(new Date());
+
+    const toggle = () => {
+        setIsOpen(!isOpen);
+    };
+
+    const timeSlots = ["6:00 AM", "7:30 AM", "10:00 AM", "1:00 PM", "3:30 PM"];
+
+    return (
+        <div>
+            <Button onClick={toggle}>Click me to change arrival</Button>
+
+            <BottomSheet
+                isOpen={isOpen}
+                shouldCloseOnOutsideClick={shouldCloseOnOutsideClick}
+                className="max-md:!px-3"
+                onClose={toggle}
+            >
+                <BottomSheet.Header>Change Arrival</BottomSheet.Header>
+
+                <BottomSheet.Body>
+                    <div className="rounded-lg bg-gray-lighter p-4">
+                        <div className="font-bold">Traveler App Test</div>
+                        <div className="mt-1 text-sm text-gray-darker">July 2, 2026 · 6:00 AM · 2 Guests</div>
+                    </div>
+
+                    <div className="mt-4 space-y-1">
+                        <span className="text-sm font-bold">Date</span>
+                        <DatePickerPopover
+                            shouldShowYearPicker
+                            value={date}
+                            getDayContent={getPricedDayContent}
+                            onChange={setDate}
+                        />
+                    </div>
+
+                    <div className="mt-4 space-y-1">
+                        <span className="text-sm font-bold">Time</span>
+                        <div className="flex flex-wrap gap-2">
+                            {timeSlots.map((slot) => (
+                                <span key={slot} className="rounded-lg border border-gray-light px-4 py-2 text-sm">
+                                    {slot}
+                                </span>
+                            ))}
+                        </div>
+                    </div>
+
+                    <div className="mt-4 rounded-lg bg-gray-lighter p-4">
+                        <div className="text-lg font-bold text-secondary">Purchase Summary</div>
+                        <p className="mt-2 text-sm text-gray-darker">New arrival: {date.toDateString()}</p>
+                        <p className="mt-1 text-sm text-gray-darker">Amount due: $0.00</p>
+                    </div>
+                </BottomSheet.Body>
+
+                <BottomSheet.Footer>
+                    <Button color="secondary" variant="outline" onClick={toggle}>
+                        Cancel
+                    </Button>
+
+                    <Button color="primary" onClick={toggle}>
+                        Save Changes
                     </Button>
                 </BottomSheet.Footer>
             </BottomSheet>


### PR DESCRIPTION
## What

Adds a new **`BottomSheet`** component — a mobile-first drawer that mirrors the existing `Modal` compound API (`Header` / `Body` / `Footer`) so it is a drop-in replacement on small screens.

- Slides up from the bottom; overlay backdrop.
- **Hugs its content height** (short content → short sheet) and **scrolls internally** when content is tall, so the footer stays pinned/visible.
- Overlay-tap-to-close is opt-in via `shouldCloseOnOutsideClick` (default `false`, matching `Modal`). Close is wired to the overlay's own click so popovers portaled outside the sheet (DatePicker calendar, ComboBox menu) don't dismiss it.
- Kept at `z-30` (same as `Modal`) so those portaled popovers stack above it.
- Storybook story included.

## Why

Traveler Self-Service flow ([QW-267](https://xola01.atlassian.net/browse/QW-267)) needs bottom-sheet drawers on mobile. Consumed by the traveler app via a `ResponsiveModal` wrapper (separate PR in `x2-seller`).

## Testing

Verified in Storybook + headed browser at mobile viewports (390-wide and shorter): short content hugs, tall content scrolls with footer pinned, overlay-close works.

JIRA: QW-267

[QW-267]: https://xola01.atlassian.net/browse/QW-267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ