### PR TITLE
ci: run Lint workflow on Node 20

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -39,16 +39,16 @@ jobs:
           echo "Hey ${{ github.actor }} you are not in a whitelisted team"
           exit 1
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{github.event.pull_request.head.sha}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
-      - name: Node.JS 16
-        uses: actions/setup-node@v3
+      - name: Node.JS 20
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
           cache: "npm"
           cache-dependency-path: "package-lock.json"
 


### PR DESCRIPTION
The `Lint` workflow (`.github/workflows/eslint.yml`) is sourced from the default branch (`master`) on `pull_request_target`, and still pins **Node 16**. The package requires `engines.node >= 20`, so `npm ci` fails with `EBADENGINE` on every PR (e.g. #431).

This bumps the workflow to **Node 20** and updates `actions/checkout` and `actions/setup-node` to v4 (matching what `next` already uses), which clears the failing install step.

Fixes the failing ES Lint check on open PRs.