### PR TITLE
ci: add Chromatic visual regression testing

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -39,6 +39,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           allow-unsafe-pr-checkout: true
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Node.JS 20
         uses: actions/setup-node@v7

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,57 @@
+name: Chromatic
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  checks: write
+
+jobs:
+  chromatic:
+    name: 🎨 Chromatic
+    runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
+
+    steps:
+      - name: Check user for team affiliation
+        uses: tspascoal/get-user-teams-membership@v4
+        id: checkUserMember
+        with:
+          GITHUB_TOKEN: ${{ secrets.ES_LINT_TOKEN }}
+          username: ${{ github.actor }}
+          organization: xola
+          team: "Engineering,X2 Consultants"
+
+      - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
+        run: |
+          echo "Hey ${{ github.actor }} you are not in a whitelisted team"
+          exit 1
+
+      - uses: actions/checkout@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          allow-unsafe-pr-checkout: true
+          fetch-depth: 0
+
+      - name: Node.JS 20
+        uses: actions/setup-node@v7
+        with:
+          node-version: 20
+          cache: "npm"
+          cache-dependency-path: "package-lock.json"
+
+      - name: Install Node Dependencies
+        run: npm ci --no-fund --no-audit
+
+      - name: Publish to Chromatic
+        uses: chromaui/action@latest
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          buildScriptName: build:storybook

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ src/theme.js
 .codegraph
 /.eslintcache
 /docs
+storybook-diff
+storybook-smoke


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that runs Chromatic on every PR (open/sync/reopen), gated to Engineering/X2 Consultants team members, skipped for dependabot PRs
- Uses `build:storybook` script and `CHROMATIC_PROJECT_TOKEN` secret to catch broken/changed components before merge
- Ignores generated `storybook-diff`/`storybook-smoke` directories in `.gitignore`

## Test plan
- [ ] Confirm `CHROMATIC_PROJECT_TOKEN` secret is set on the repo
- [ ] Open a test PR and verify the Chromatic check runs and reports build results
- [ ] Add "Chromatic" as a required status check in branch protection once verified