### PR TITLE
revert: downgrade @headlessui/react and react-select

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "2.4.0",
             "license": "MIT",
             "dependencies": {
-                "@headlessui/react": "^1.7.19",
+                "@headlessui/react": "^1.4.0",
                 "@tailwindcss/forms": "^0.5.11",
                 "@tailwindcss/line-clamp": "^0.3.1",
                 "@tippyjs/react": "^4.2.6",
@@ -25,7 +25,7 @@
                 "react-day-picker": "^7.4.10",
                 "react-hot-toast": "^2.6.0",
                 "react-hotkeys-hook": "^3.4.0",
-                "react-select": "^5.10.2",
+                "react-select": "^5.7.0",
                 "react-textarea-autosize": "^8.5.9",
                 "tippy.js": "^6.3.7",
                 "use-debounce": "^10.1.1"
@@ -2763,13 +2763,9 @@
             "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww=="
         },
         "node_modules/@headlessui/react": {
-            "version": "1.7.19",
-            "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.19.tgz",
-            "integrity": "sha512-Ll+8q3OlMJfJbAKM/+/Y2q6PPYbryqNTXDbryx7SXLIDamkF6iQFbriYHga0dY44PvDhvvBWCx1Xj4U5+G4hOw==",
-            "dependencies": {
-                "@tanstack/react-virtual": "^3.0.0-beta.60",
-                "client-only": "^0.0.1"
-            },
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.4.0.tgz",
+            "integrity": "sha512-C+FmBVF6YGvqcEI5fa2dfVbEaXr2RGR6Kw1E5HXIISIZEfsrH/yuCgsjWw5nlRF9vbCxmQ/EKs64GAdKeb8gCw==",
             "engines": {
                 "node": ">=10"
             },
@@ -5969,31 +5965,6 @@
                 "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
             }
         },
-        "node_modules/@tanstack/react-virtual": {
-            "version": "3.14.9",
-            "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.9.tgz",
-            "integrity": "sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==",
-            "dependencies": {
-                "@tanstack/virtual-core": "3.17.7"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/tannerlinsley"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/@tanstack/virtual-core": {
-            "version": "3.17.7",
-            "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.7.tgz",
-            "integrity": "sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/tannerlinsley"
-            }
-        },
         "node_modules/@tippyjs/react": {
             "version": "4.2.6",
             "resolved": "https://registry.npmjs.org/@tippyjs/react/-/react-4.2.6.tgz",
@@ -7606,11 +7577,6 @@
             "optionalDependencies": {
                 "@colors/colors": "1.5.0"
             }
-        },
-        "node_modules/client-only": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
-            "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
         },
         "node_modules/cliui": {
             "version": "8.0.1",
@@ -14322,9 +14288,9 @@
             }
         },
         "node_modules/react-select": {
-            "version": "5.10.2",
-            "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.10.2.tgz",
-            "integrity": "sha512-Z33nHdEFWq9tfnfVXaiM12rbJmk+QjFEztWLtmXqQhz6Al4UZZ9xc0wiatmGtUOCCnHN0WizL3tCMYRENX4rVQ==",
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.7.0.tgz",
+            "integrity": "sha512-lJGiMxCa3cqnUr2Jjtg9YHsaytiZqeNOKeibv6WF5zbK/fPegZ1hg3y/9P1RZVLhqBTs0PfqQLKuAACednYGhQ==",
             "dependencies": {
                 "@babel/runtime": "^7.12.0",
                 "@emotion/cache": "^11.4.0",
@@ -14334,11 +14300,11 @@
                 "memoize-one": "^6.0.0",
                 "prop-types": "^15.6.0",
                 "react-transition-group": "^4.3.0",
-                "use-isomorphic-layout-effect": "^1.2.0"
+                "use-isomorphic-layout-effect": "^1.1.2"
             },
             "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
             }
         },
         "node_modules/react-style-singleton": {
@@ -18547,13 +18513,9 @@
             "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww=="
         },
         "@headlessui/react": {
-            "version": "1.7.19",
-            "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.19.tgz",
-            "integrity": "sha512-Ll+8q3OlMJfJbAKM/+/Y2q6PPYbryqNTXDbryx7SXLIDamkF6iQFbriYHga0dY44PvDhvvBWCx1Xj4U5+G4hOw==",
-            "requires": {
-                "@tanstack/react-virtual": "^3.0.0-beta.60",
-                "client-only": "^0.0.1"
-            }
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.4.0.tgz",
+            "integrity": "sha512-C+FmBVF6YGvqcEI5fa2dfVbEaXr2RGR6Kw1E5HXIISIZEfsrH/yuCgsjWw5nlRF9vbCxmQ/EKs64GAdKeb8gCw=="
         },
         "@humanwhocodes/config-array": {
             "version": "0.13.0",
@@ -20632,19 +20594,6 @@
             "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.3.1.tgz",
             "integrity": "sha512-pNr0T8LAc3TUx/gxCfQZRe9NB2dPEo/cedPHzUGIPxqDMhgjwNm6jYxww4W5l0zAsAddxr+XfZcqttGiFDgrGg=="
         },
-        "@tanstack/react-virtual": {
-            "version": "3.14.9",
-            "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.9.tgz",
-            "integrity": "sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==",
-            "requires": {
-                "@tanstack/virtual-core": "3.17.7"
-            }
-        },
-        "@tanstack/virtual-core": {
-            "version": "3.17.7",
-            "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.7.tgz",
-            "integrity": "sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA=="
-        },
         "@tippyjs/react": {
             "version": "4.2.6",
             "resolved": "https://registry.npmjs.org/@tippyjs/react/-/react-4.2.6.tgz",
@@ -21916,11 +21865,6 @@
                 "@colors/colors": "1.5.0",
                 "string-width": "^4.2.0"
             }
-        },
-        "client-only": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
-            "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
         },
         "cliui": {
             "version": "8.0.1",
@@ -26765,9 +26709,9 @@
             }
         },
         "react-select": {
-            "version": "5.10.2",
-            "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.10.2.tgz",
-            "integrity": "sha512-Z33nHdEFWq9tfnfVXaiM12rbJmk+QjFEztWLtmXqQhz6Al4UZZ9xc0wiatmGtUOCCnHN0WizL3tCMYRENX4rVQ==",
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.7.0.tgz",
+            "integrity": "sha512-lJGiMxCa3cqnUr2Jjtg9YHsaytiZqeNOKeibv6WF5zbK/fPegZ1hg3y/9P1RZVLhqBTs0PfqQLKuAACednYGhQ==",
             "requires": {
                 "@babel/runtime": "^7.12.0",
                 "@emotion/cache": "^11.4.0",
@@ -26777,7 +26721,7 @@
                 "memoize-one": "^6.0.0",
                 "prop-types": "^15.6.0",
                 "react-transition-group": "^4.3.0",
-                "use-isomorphic-layout-effect": "^1.2.0"
+                "use-isomorphic-layout-effect": "^1.1.2"
             }
         },
         "react-style-singleton": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "test": "jest"
     },
     "dependencies": {
-        "@headlessui/react": "^1.7.19",
+        "@headlessui/react": "^1.4.0",
         "@tailwindcss/forms": "^0.5.11",
         "@tailwindcss/line-clamp": "^0.3.1",
         "@tippyjs/react": "^4.2.6",
@@ -47,7 +47,7 @@
         "react-day-picker": "^7.4.10",
         "react-hot-toast": "^2.6.0",
         "react-hotkeys-hook": "^3.4.0",
-        "react-select": "^5.10.2",
+        "react-select": "^5.7.0",
         "react-textarea-autosize": "^8.5.9",
         "tippy.js": "^6.3.7",
         "use-debounce": "^10.1.1"


### PR DESCRIPTION
## Summary
- Reverts @headlessui/react ^1.7.19 -> ^1.4.0
- Reverts react-select ^5.10.2 -> ^5.7.0
- Both bumped in #441; newer versions causing widespread Selenium flakiness downstream

## Test plan
- [x] `npm run lint` clean (pre-existing complexity warnings only)
- [x] `npm test` passes (9/9)
- [x] `npm run build` succeeds