### PR TITLE
Enable tree-shaking for @xola/icons

### DIFF
--- a/src/icons/package.json
+++ b/src/icons/package.json
@@ -1,9 +1,11 @@
 {
     "name": "@xola/icons",
-    "version": "1.1.31",
+    "version": "1.1.32",
     "description": "Xola's icon set",
     "main": "./index.ts",
     "types": "./index.ts",
+    "sideEffects": false,
+    "files": ["index.ts", "src"],
     "scripts": {
         "format": "prettier --write -l src",
         "lint": "eslint --cache --cache-strategy content --ext .ts,.tsx --fix src",

--- a/src/icons/src/helpers/icon.tsx
+++ b/src/icons/src/helpers/icon.tsx
@@ -8,7 +8,7 @@ export interface IconProps extends React.SVGProps<SVGSVGElement> {
 
 export type IconComponent = React.FC<IconProps> & { tags?: string[] };
 
-export const createIcon = (Icon: (props: IconProps) => JSX.Element): IconComponent => {
+export const createIcon = (Icon: (props: IconProps) => React.ReactElement): IconComponent => {
     const IconContainer: IconComponent = ({ size = "small", className, ...rest }) => {
         return <Icon className={clsx(iconSizes[size], "relative -top-0.25 inline-block", className)} {...rest} />;
     };


### PR DESCRIPTION
- **fix(icons): enable tree-shaking with sideEffects false**
- **fix(icons): use React.ReactElement for React 19 compat**
